### PR TITLE
Update location of recovery_data

### DIFF
--- a/administrators-guide/admin-troubleshooting-guide.md
+++ b/administrators-guide/admin-troubleshooting-guide.md
@@ -43,13 +43,13 @@ If the control plane is accessible from your network but is down, we are already
 When RudderStack enters "degraded" mode, it will only log the event and not process the event. If the issue why the server entered the degraded mode is temporary \(Transformer is down\), then fix the issue and restart the server in the normal mode.
 
 {% hint style="success" %}
-You can restart the server in the normal mode by updating the `/tmp/recovery_data.json`. Set Mode to "normal"
+You can restart the server in the normal mode by updating the `/data/rudderstack/recovery_data.json`. Set Mode to "normal"
 {% endhint %}
 
 ## RudderStack has entered the maintenance mode. What should I do?
 
 When RudderStack enters "maintenance" mode, we take a back up of the old database and create a new database in the "degraded" mode. RudderStack will only log the event and not process the event in this case. If the issue is fixed, start another instance of RudderStack server in normal mode but in a different port \(say 8081\) pointing to the old DB. That will drain all the events in the old DB.  
-Then restart the actual server in the normal mode by updating the `/tmp/recovery_data.json`. Set the mode to "normal"_._ It will resume routing pending events and the ordering of the events is guaranteed.
+Then restart the actual server in the normal mode by updating the `/data/rudderstack/recovery_data.json`. Set the mode to "normal"_._ It will resume routing pending events and the ordering of the events is guaranteed.
 
 ## The disk usage is increasing. What should I do?
 

--- a/administrators-guide/admin-troubleshooting-guide.md
+++ b/administrators-guide/admin-troubleshooting-guide.md
@@ -10,7 +10,7 @@ This section contains solutions to some of the commonly faced issues you are lik
 
 ## The SDK returns success, but I don't see any events in my destination. What **should I do?**
 
-1. Check if the server is running in _normal_ mode in the file `/tmp/recovery_data.json` .
+1. Check if the server is running in _normal_ mode in the file `/data/rudderstack/recovery_data.json` .
 2. If the server is in "degraded" or "maintenance" mode, RudderStack just stores the events and will not process them.
 
 ##  My Data Plane does not start. What should I do?

--- a/administrators-guide/admin-troubleshooting-guide.md
+++ b/administrators-guide/admin-troubleshooting-guide.md
@@ -10,7 +10,7 @@ This section contains solutions to some of the commonly faced issues you are lik
 
 ## The SDK returns success, but I don't see any events in my destination. What **should I do?**
 
-1. Check if the server is running in _normal_ mode in the file `/data/rudderstack/recovery_data.json` .
+1. Check if the server is running in _normal_ mode in the file `/data/rudderstack/recovery_data.json` or `/tmp/recovery_data.json`.
 2. If the server is in "degraded" or "maintenance" mode, RudderStack just stores the events and will not process them.
 
 ##  My Data Plane does not start. What should I do?
@@ -43,13 +43,13 @@ If the control plane is accessible from your network but is down, we are already
 When RudderStack enters "degraded" mode, it will only log the event and not process the event. If the issue why the server entered the degraded mode is temporary \(Transformer is down\), then fix the issue and restart the server in the normal mode.
 
 {% hint style="success" %}
-You can restart the server in the normal mode by updating the `/data/rudderstack/recovery_data.json`. Set Mode to "normal"
+You can restart the server in the normal mode by updating the `/data/rudderstack/recovery_data.json` or `/tmp/recovery_data.json`. Set Mode to "normal"
 {% endhint %}
 
 ## RudderStack has entered the maintenance mode. What should I do?
 
 When RudderStack enters "maintenance" mode, we take a back up of the old database and create a new database in the "degraded" mode. RudderStack will only log the event and not process the event in this case. If the issue is fixed, start another instance of RudderStack server in normal mode but in a different port \(say 8081\) pointing to the old DB. That will drain all the events in the old DB.  
-Then restart the actual server in the normal mode by updating the `/data/rudderstack/recovery_data.json`. Set the mode to "normal"_._ It will resume routing pending events and the ordering of the events is guaranteed.
+Then restart the actual server in the normal mode by updating the `/data/rudderstack/recovery_data.json` or `/tmp/recovery_data.json`. Set the mode to "normal"_._ It will resume routing pending events and the ordering of the events is guaranteed.
 
 ## The disk usage is increasing. What should I do?
 


### PR DESCRIPTION
## Description of the change

> The  location of `recovery_data.json` file seems to be different than what's in docs. I'm running latest version of rudder, so updating the docs.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
