### PR TITLE
Make consistent URL reference to the JS SDK

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
@@ -67,7 +67,7 @@ rudderanalytics=window.rudderanalytics=[];for(var methods=["load","page","track"
     rudderanalytics.page();
 </script>
 
-<script src="https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"></script>
+<script src="https://cdn.rudderlabs.com/rudder-analytics.min.js"></script>
 ```
 
 {% hint style="success" %}
@@ -79,7 +79,7 @@ rudderanalytics=window.rudderanalytics=[];for(var methods=["load","page","track"
 // Combining the initialization and the above async script together 
 
 <script type="text/javascript"> 
-!function(){var e=window.rudderanalytics=window.rudderanalytics||[];e.methods=["load","page","track","identify","alias","group","ready","reset","getAnonymousId","setAnonymousId"],e.factory=function(t){return function(){var r=Array.prototype.slice.call(arguments);return r.unshift(t),e.push(r),e}};for(var t=0;t<e.methods.length;t++){var r=e.methods[t];e[r]=e.factory(r)}e.loadJS=function(e,t){var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)},e.loadJS(),
+!function(){var e=window.rudderanalytics=window.rudderanalytics||[];e.methods=["load","page","track","identify","alias","group","ready","reset","getAnonymousId","setAnonymousId"],e.factory=function(t){return function(){var r=Array.prototype.slice.call(arguments);return r.unshift(t),e.push(r),e}};for(var t=0;t<e.methods.length;t++){var r=e.methods[t];e[r]=e.factory(r)}e.loadJS=function(e,t){var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.rudderlabs.com/rudder-analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)},e.loadJS(),
  e.load(WRITE_KEY, DATA_PLANE_URL), e.page()}(); 
 </script>
 ```


### PR DESCRIPTION
## Description of the change

In some places in this document, the JS SDK is referenced with the version number Eg: https://cdn.rudderlabs.com/v1/rudder-analytics.min.js whereas in most other prominent places, the SDK is referenced directly https://cdn.rudderlabs.com/rudder-analytics.min.js .

This commit updates these references to the non-versioned URL so that the latest version is always referenced.