### PR TITLE
Clarified data plane url variable

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-node-sdk.md
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-node-sdk.md
@@ -28,7 +28,7 @@ To use the SDK, run the following code snippet:
 const Analytics = require("@rudderstack/rudder-sdk-node");
 
 // RudderStack requires the batch endpoint of the server you are running
-const client = new Analytics(WRITE_KEY, DATA_PLANE_URL/v1/batch);
+const client = new Analytics(WRITE_KEY, `${DATA_PLANE_URL}/v1/batch`);
 ```
 
 ## Identify


### PR DESCRIPTION
The data plane url parameter is confusing to me since it looks like it's meant to append a path to the hostname string, but it's not valid javascript and it's not totally clear what the intended modification here is. I think what you guys mean to show is that the path "/v1/batch" should be appended to the dataplane hostname URL, but I think it would be clearer to show that as a string template.

## Description of the change

> Clarified dataplane url with template string
