### PR TITLE
Added defaultStorage load option in JS SDK

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
@@ -198,7 +198,8 @@ The `options` parameter in the above `load` call looks like the following:
  integrations: IntegrationOpts,
  configUrl: string,  // defaults to https://api.rudderlabs.com
  queueOptions: QueueOpts,
- loadIntegration: boolean // defaults to true.
+ loadIntegration: boolean, // defaults to true.
+ defaultStorage: string // defaults to "cookies"
 }
 ```
 
@@ -211,6 +212,13 @@ It includes the following details:
 | **`configUrl`** | String | Defaults to **`https://api.rudderlabs.com`**. You need to provide the server endpoint serving your destination configurations. **`sourceConfig`** is appended to this endpoint by the SDK. |
 | **`queueOpts`** | - | Refer to **`QueueOpts`** |
 | **`loadIntegration`** | Boolean | Defaults to **`true`**. If set to **`false`**, the destination SDKs are not fetched by the SDK. This is supported for **Amplitude** and **Google Analytics**. |
+| **`defaultStorage`** | String | Defaults to **`cookies`**. You need to specify the default persistent storage type for the SDK. Options include **`cookies`** and **`localstorage`**. |
+
+{% hint style="info" %}
+The above `defaultStorage` parameter is only to specify the default storage type to be used by the SDK but does not guarantee the eventual persistent storage type used by the SDK.
+
+For example, if the `defaultStorage` parameter is set to **`cookies`** and cookies are unavailable, then local storage would be used as the persistent storage and vice-versa.
+{% endhint %}
 
 * The structure of **`IntegrationOpts`** looks like the following:
 
@@ -375,7 +383,9 @@ There is no need to call`identify()`for anonymous visitors to your website. Such
 The JavaScript SDK generates one unique `anonymousId` , stores it in a cookie named `rl_anonymous_id` in the top-level domain, and attaches to every subsequent event. This helps in identifying the users from other sites that are hosted under a sub-domain.
 
 {% hint style="info" %}
-As an example, if you include the RudderStack JavaScript SDK in both **admin.samplewebsite.com** and **app.samplewebsite.com**, the SDK will store the cookie in the top-level domain **samplewebsite.com**.
+As an example, if you include the RudderStack JavaScript SDK in both **admin.samplewebsite.com** and **app.samplewebsite.com**, the SDK will store the cookie in the top-level domain **samplewebsite.com**. 
+
+However, this functionality is only applicable if the SDK uses cookies as its persistent storage which is configurable via `defaultStorage` parameter in the **`load`** API options.
 {% endhint %}
 
 If you identify a user with your application's unique identifier like email, database ID etc. RudderStack stores this ID in a cookie named `rl_user_id` and attaches to every event.

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
@@ -212,12 +212,12 @@ It includes the following details:
 | **`configUrl`** | String | Defaults to **`https://api.rudderlabs.com`**. You need to provide the server endpoint serving your destination configurations. **`sourceConfig`** is appended to this endpoint by the SDK. |
 | **`queueOpts`** | - | Refer to **`QueueOpts`** |
 | **`loadIntegration`** | Boolean | Defaults to **`true`**. If set to **`false`**, the destination SDKs are not fetched by the SDK. This is supported for **Amplitude** and **Google Analytics**. |
-| **`defaultStorage`** | String | Defaults to **`cookies`**. You need to specify the default persistent storage type for the SDK. Options include **`cookies`** and **`localstorage`**. |
+| **`defaultStorage`** | String | Defaults to **`cookies`**. You need to specify the default persistent storage type for the SDK. The options include **`cookies`** and **`localstorage`**. |
 
 {% hint style="info" %}
-The above `defaultStorage` parameter is only to specify the default storage type to be used by the SDK but does not guarantee the eventual persistent storage type used by the SDK.
+The above `defaultStorage` parameter only specifies the default storage type used by the SDK. It **does not** guarantee the eventual persistent storage type used by the SDK.
 
-For example, if the `defaultStorage` parameter is set to **`cookies`** and cookies are unavailable, then local storage would be used as the persistent storage and vice-versa.
+For example, if the `defaultStorage` parameter is set to **`cookies`** and the cookies are unavailable, then local storage would be used as the persistent storage.
 {% endhint %}
 
 * The structure of **`IntegrationOpts`** looks like the following:
@@ -383,9 +383,9 @@ There is no need to call`identify()`for anonymous visitors to your website. Such
 The JavaScript SDK generates one unique `anonymousId` , stores it in a cookie named `rl_anonymous_id` in the top-level domain, and attaches to every subsequent event. This helps in identifying the users from other sites that are hosted under a sub-domain.
 
 {% hint style="info" %}
-As an example, if you include the RudderStack JavaScript SDK in both **admin.samplewebsite.com** and **app.samplewebsite.com**, the SDK will store the cookie in the top-level domain **samplewebsite.com**. 
+For example, if you include the RudderStack JavaScript SDK in both **admin.samplewebsite.com** and **app.samplewebsite.com**, the SDK will store the cookie in the top-level domain **samplewebsite.com**. 
 
-However, this functionality is only applicable if the SDK uses cookies as its persistent storage which is configurable via `defaultStorage` parameter in the **`load`** API options.
+However, this functionality is only applicable if the SDK uses cookies as its persistent storage which is configurable via the `defaultStorage` parameter in the **`load`** API options.
 {% endhint %}
 
 If you identify a user with your application's unique identifier like email, database ID etc. RudderStack stores this ID in a cookie named `rl_user_id` and attaches to every event.

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/README.md
@@ -121,8 +121,8 @@ This NPM module is only meant to be used for a browser installation. If you want
 
 ```jsx
 import * as rudderanalytics from "rudder-sdk-js"
-rudderanalytics.ready(() => {console.log("we are all set!!!")})
 rudderanalytics.load(WRITE_KEY, DATA_PLANE_URL)
+rudderanalytics.ready(() => {console.log("We are all set!")})
 export { rudderanalytics }
 ```
 


### PR DESCRIPTION
## Description of the change

Updated JS SDK docs to add `defaultStorage` load option added as part of https://github.com/rudderlabs/rudder-sdk-js/pull/336

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
