### PR TITLE
SSL option added in init fn

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/php.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/php.mdx
@@ -38,15 +38,32 @@ Rudder::init(WRITE_KEY, array(
   "consumer"       => "lib_curl", // fork_curl
   "debug"          => true,
   "max_queue_size" => 10000,
-  "batch_size"     => 100
+  "batch_size"     => 100,
+  "ssl"            => true // default value true
 ));
 ```
 
 <div class="warningBlock">
 
-We append the protocol to <code class="inline-code">DATA_PLANE_URL</code> before sending the events to RudderStack server.
+We accept the <code class="inline-code">DATA_PLANE_URL</code> with or without the protocol.
 
-For example if your dataPlaneUrl is <code class="inline-code">https://example.dataplane.com</code> mention only <code class="inline-code">example.dataplane.com</code>
+For example if your data_plane_url is <code class="inline-code">https://example.dataplane.com</code> below formats are accepted:
+
+1. <code class="inline-code">https://example.dataplane.com</code>
+2. <code class="inline-code">example.dataplane.com</code>
+
+In case the protocol is <code class="inline-code">http</code> (<code class="inline-code">http://example.dataplane.com</code>) data_plane_url should be:
+
+1. <code class="inline-code">http://example.dataplane.com</code> and set <code class="inline-code">
+     ssl
+   </code> option in <code class="inline-code">init</code> to <code class="inline-code">
+     false
+   </code>
+2. <code class="inline-code">example.dataplane.com</code> and set <code class="inline-code">
+     ssl
+   </code> option in <code class="inline-code">init</code> to <code class="inline-code">
+     false
+   </code>
 
 </div>
 
@@ -246,7 +263,8 @@ The `alias` call allows you to associate one identity with another.
 
 <div class="infoBlock">
 
-<code class="inline-code">alias</code> is an advanced method. However, it is required when managing user identities in some destinations.
+<code class="inline-code">alias</code> is an advanced method. However, it is required
+when managing user identities in some destinations.
 
 </div>
 


### PR DESCRIPTION
## Description of the change

> Data plane URL validation modified. Now it accepts data plane url with or without protocol. And we accept another option in init "SSL" a boolean value. In case of HTTP need to SSL to false.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
