### PR TITLE
Add specific place to find data plane URL for RudderStack Cloud in FAQ

### DIFF
--- a/faqs.mdx
+++ b/faqs.mdx
@@ -45,7 +45,7 @@ Here's how to get the Data Plane URL:
 An open-source Data Plane URL looks like `http:localhost:8080` where `8080` is typically the port where your RudderStack Data Plane is hosted.  
 </div>
 
-* If you're using [**RudderStack Cloud** **Free**](https://app.rudderlabs.com/signup?type=freetrial), the data plane URL is provided in the dashboard. 
+* If you're using [**RudderStack Cloud** **Free**](https://app.rudderlabs.com/signup?type=freetrial), the data plane URL is provided in the dashboard at the top of the Connections page.
 * If you're using the [**pro or enterprise**](https://rudderstack.com/pricing) version of RudderStack, [**contact us**](https://rudderstack.com/join-rudderstack-slack-community) for the Data Plane URL with the email ID you used to sign up for RudderStack.
 
 #### 3. To get started with RudderStack on my local machine, is it mandatory to get the workspace token from RudderStack dashboard?


### PR DESCRIPTION
## Description of the change

Took me way too long to find the data plane URL in the dashboard 😅
