### PR TITLE
maxRetryDelay Default Value Correction

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/index.mdx
@@ -535,7 +535,7 @@ The structure of **`QueueOpts`** is shown below:
 
 ```javascript
 {
-  maxRetryDelay: 3600000,
+  maxRetryDelay: 360000,
   minRetryDelay: 1000,
   backoffFactor: 2,
   maxAttempts: 10,

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/index.mdx
@@ -535,7 +535,7 @@ The structure of **`QueueOpts`** is shown below:
 
 ```javascript
 {
-  maxRetryDelay: 360000,
+  maxRetryDelay: 3600000,
   minRetryDelay: 1000,
   backoffFactor: 2,
   maxAttempts: 10,
@@ -547,8 +547,8 @@ The following table describes each of the above parameters in detail:
 
 | **Parameter**   | **Type**| **Description**                                                      | **Default value** |
 | :-------------- | :------ | :--------------------------------------------------------------------|:------------------|
-| `maxRetryDelay` | Integer | The upper limit on the maximum delay for an event.                   | 36000ms           |
-| `minRetryDelay` | Integer | The minimum delay expected before sending an event.                  | 1000ms            |
+| `maxRetryDelay` | Integer | The upper limit on the maximum delay for an event (in ms)            | 360000            |
+| `minRetryDelay` | Integer | The minimum delay expected before sending an event (in ms)           | 1000              |
 | `backoffFactor` | Integer | Refers to the exponential base.                                      | 2                 |
 | `maxAttempts`   | Integer | Maximum number of attempts to send the event to the destination.     | 10                |
 | `maxItems`      | Integer | Maximum number of events kept in the storage.                        |    100            |


### PR DESCRIPTION
## Description of the change

> Updated the correct values for `maxRetryDelay` from 36000ms to 360000ms.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
