### PR TITLE
Salesforce documentation update

### DIFF
--- a/destinations/crm/salesforce.mdx
+++ b/destinations/crm/salesforce.mdx
@@ -95,6 +95,11 @@ This snippet identifies a unique user based on the `userid` and the associated t
 
 When the `identify` method is called, RudderStack checks if the lead already exists using the `email` property. If yes, the lead is updated with the traits passed in the `identify` call. If no lead exists, a new lead is created in Salesforce.
 
+<div class="infoBlock">
+  
+  If a lead is already converted into a contact, RudderStack will map the user ID to <code class="inline-code">contactId</a>. Otherwise, the user ID will be mapped to the <code class="inline-code">leadId</a>.
+</div>
+
 <div class="warningBlock">
 
 It is mandatory to include `'Salesforce':true` in every Salesforce integration object. As Salesforce has strict API limits, this is required in order to prevent the users from hitting their limits. By default, RudderStack does not send `identify` calls to Salesforce. Hence, any `identify` call that does not include `'Salesforce':true` in its payload will be ignored.

--- a/destinations/crm/salesforce.mdx
+++ b/destinations/crm/salesforce.mdx
@@ -97,7 +97,7 @@ When the `identify` method is called, RudderStack checks if the lead already exi
 
 <div class="infoBlock">
   
-  If a lead is already converted into a contact, RudderStack will map the user ID to <code class="inline-code">contactId</code>. Otherwise, the user ID will be mapped to the <code class="inline-code">leadId</code>.
+  When you make an <code class="inline-code">identify</code> call with a set of user traits, RudderStack will update the appropriate record in Salesforce depending on whether it is a lead or a contact using its lead or contact ID respectively.
 </div>
 
 <div class="warningBlock">

--- a/destinations/crm/salesforce.mdx
+++ b/destinations/crm/salesforce.mdx
@@ -93,7 +93,7 @@ rudderanalytics.identify('userid', {
 
 This snippet identifies a unique user based on the `userid` and the associated traits passed in the `identify` call.
 
-When the `identify` method is called, RudderStack checks if the lead already exists using the `email` property. If yes, the lead is updated with the traits passed in the `identify` call. If no lead exists, a new lead is created in Salesforce.
+When the `identify` method is called, RudderStack checks if the lead already exists using the `email` property. If yes, the lead/contact is updated with the traits passed in the `identify` call. If no lead exists, a new lead is created in Salesforce.
 
 <div class="infoBlock">
   

--- a/destinations/crm/salesforce.mdx
+++ b/destinations/crm/salesforce.mdx
@@ -97,7 +97,7 @@ When the `identify` method is called, RudderStack checks if the lead already exi
 
 <div class="infoBlock">
   
-  When you make an <code class="inline-code">identify</code> call with a set of user traits, RudderStack will update the appropriate record in Salesforce depending on whether it is a lead or a contact using its lead or contact ID respectively.
+  When you make an <code class="inline-code">identify</code> call with a set of user traits, RudderStack will update the appropriate record in Salesforce depending on whether it is a lead or a contact using its lead or contact ID.
 </div>
 
 <div class="warningBlock">

--- a/destinations/crm/salesforce.mdx
+++ b/destinations/crm/salesforce.mdx
@@ -97,7 +97,7 @@ When the `identify` method is called, RudderStack checks if the lead already exi
 
 <div class="infoBlock">
   
-  If a lead is already converted into a contact, RudderStack will map the user ID to <code class="inline-code">contactId</a>. Otherwise, the user ID will be mapped to the <code class="inline-code">leadId</a>.
+  If a lead is already converted into a contact, RudderStack will map the user ID to <code class="inline-code">contactId</code>. Otherwise, the user ID will be mapped to the <code class="inline-code">leadId</code>.
 </div>
 
 <div class="warningBlock">

--- a/destinations/crm/salesforce.mdx
+++ b/destinations/crm/salesforce.mdx
@@ -93,7 +93,7 @@ rudderanalytics.identify('userid', {
 
 This snippet identifies a unique user based on the `userid` and the associated traits passed in the `identify` call.
 
-When the `identify` method is called, RudderStack checks if the lead already exists using the `email` property. If yes, the lead/contact is updated with the traits passed in the `identify` call. If no lead exists, a new lead is created in Salesforce.
+When the `identify` method is called, RudderStack checks if the lead already exists using the `email` property. If yes, the lead/contact is updated with the traits passed in the `identify` call. If not, a new lead is created in Salesforce.
 
 <div class="infoBlock">
   


### PR DESCRIPTION
## Description of the change

> Added information on mapping to `contactId` once a lead converts to a contact.

## Type of documentation
- [ ] New documentation
- [ ] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Salesforce contact information](https://www.notion.so/rudderstacks/Salesforce-Contact-Doc-Update-4608cc9f497b4d7e95c1050c8a35fc4d)