### PR TITLE
ActiveCampaign Documentation Updates

### DIFF
--- a/destinations/marketing/activecampaign.mdx
+++ b/destinations/marketing/activecampaign.mdx
@@ -223,7 +223,7 @@ rudderanalytics.track("Product Purchased", {
 
 In the above snippet, RudderStack captures the information related to the `Product Purchased` event, along with any additional information about that event - in this case the product `name`.
 
-RudderStack also maps `properties.eventData` present within the `track` event properties to ActiveCampaign's `eventdata` field, as shown:
+RudderStack also maps `eventData` present within the `track` event properties to ActiveCampaign's `eventdata` field, as shown:
 
 ```javascript
 rudderanalytics.track("Product Purchased", {

--- a/destinations/marketing/activecampaign.mdx
+++ b/destinations/marketing/activecampaign.mdx
@@ -223,6 +223,15 @@ rudderanalytics.track("Product Purchased", {
 
 In the above snippet, RudderStack captures the information related to the `Product Purchased` event, along with any additional information about that event - in this case the product `name`.
 
+RudderStack also maps `properties.eventData` present within the `track` event properties to ActiveCampaign's `eventdata` field, as shown:
+
+```javascript
+rudderanalytics.track("Product Purchased", {
+  name: "Rubik's Cube",
+  eventData: "Learn while having fun"
+})
+```
+
 <div class="warningBlock">
 
 The <code class="inline-code">track</code> event name must contain only alphanumeric characters. ActiveCampaign rejects events with any special characters in the name.


### PR DESCRIPTION
## Description of the change

> Added information on the `eventData` mapping in the `track` call.

## Type of documentation
- [ ] New documentation
- [ ] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Active Campaign Event Discrepancy](https://www.notion.so/rudderstacks/Active-Campaign-Event-Discrepancy-946a432c7d574286818c855370a2e0cf)
