### PR TITLE
Android SDK configuration for advertising IDs

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -175,7 +175,6 @@ RudderClient rudderClient = RudderClient.getInstance(
                 .withDataPlaneUrl(DATA_PLANE_URL)
                 .withTrackLifecycleEvents(true)
                 .withRecordScreenViews(true)
-                .withAutoCollectAdvertId(false)
                 .build()
 );
 ```

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -587,11 +587,11 @@ You can configure your client based on the following parameters using `RudderCon
 | `dataPlaneUrl`          | String  | Your data plane URL.                                                             | `https://hosted.rudderlabs.com` |
 | `flushQueueSize`        | Integer     | Number of events in a batch request to the RudderStack server.              | `30`                                                     |
 | `dbThresholdCount`      | Integer     | Number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the database.                          | `10000`                                                  |
-| `sleepcount`          | Integer     | Minimum waiting time to flush the events to the RudderStack server. The minimum value can be set to 1 second.      | `10 seconds`                                             |
-| `configRefreshInterval` | Integer     | It will fetch the config from `dashboard` after the specified time          | `2 hours`       |
-| `trackLifecycleEvents`  | Boolean | Whether SDK will capture application life cycle events automatically.                     | `true`                                                   |
-| `recordScreenViews`     | Boolean | Whether SDK will capture screen view events automatically.                   | `false`            |
-| `autoCollectAdvertId`  | Boolean | Whether the SDK will collect the advertising ID.  | `false` |
+| `sleepcount`          | Integer     | Minimum waiting time to flush the events to the RudderStack server. The minimum value can be set to `1 second`.      | `10 seconds`                                             |
+| `configRefreshInterval` | Integer     | The SDK will fetch the config from `dashboard` after the specified time          | `2 hours`       |
+| `trackLifecycleEvents`  | Boolean | Determines if the SDK will automatically capture the application lifecycle events.                     | `true`                                                   |
+| `recordScreenViews`     | Boolean | Determines if the SDK will automatically capture the screen view events.                   | `false`            |
+| `autoCollectAdvertId`  | Boolean | Determines if the SDK will collect the advertisement ID.  | `false` |
 | `controlPlaneUrl`       | String  | Change this parameter **only if** you are self-hosting the control plane. Check the [Self-hosted control plane](#self-hosted-control-plane) section below for more information. The SDK will add `/sourceConfig` along with this URL to fetch the source configuration. | [https://api.rudderlabs.com](https://api.rudderlabs.com) |
 
 A sample code snippet to configure your client using `RudderConfig.Builder` is shown below:
@@ -648,9 +648,11 @@ RudderClient.putDeviceToken("your_device_token");
     </TabPanels>
 </Tabs>
 
-## Setting the advertising ID using `putAdvertisingId`
+## Setting the advertisement ID using `putAdvertisingId`
 
-By default, RudderStack collects the advertisement ID **only** if `withAutoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+By default, RudderStack collects the advertisement ID **only** if the following three conditions are met:
+
+- `withAutoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
 
 ```kotlin
 val rudderClient = RudderClient.getInstance(
@@ -664,17 +666,10 @@ val rudderClient = RudderClient.getInstance(
         .build()
 )
 ```
+- `com.google.android.gms.ads.identifier.AdvertisingIdClient` is present in your application's class path.
+- `limitAdTracking`is not enabled for your device.
 
-<div class="warningBlock">
-
-  For RudderStack to collect the advertisement ID, the following conditions must also be met:
-  <ul>
-    <li><code class="inline-code">com.google.android.gms.ads.identifier.AdvertisingIdClient</code> must be present in your application's class path.</li>
-    <li><code class="inline-code">limitAdTracking</code> must not be enabled for your device.</li>
-  </ul>
-</div>
-
-To set your own advertising ID, you can use the `putAdvertisingId` method and pass the advertising ID, as shown:
+To set your own advertisement ID, you can use the `putAdvertisingId` method, as shown:
 
 ```java
 RudderClient.putAdvertisingId(<ADVERTISING_ID>);

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -159,7 +159,6 @@ val rudderClient = RudderClient.getInstance(
         .withDataPlaneUrl(DATA_PLANE_URL)
         .withTrackLifecycleEvents(true)
         .withRecordScreenViews(true)
-        .withAutoCollectAdvertId(false)
         .build()
 )
 ```
@@ -650,9 +649,22 @@ RudderClient.putDeviceToken("your_device_token");
     </TabPanels>
 </Tabs>
 
-## Advertisement ID
+## Setting the advertising ID using `putAdvertisingId`
 
-RudderStack collects the advertisement ID **only** if `withAutoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client).
+By default, RudderStack collects the advertisement ID **only** if `withAutoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+
+```kotlin
+val rudderClient = RudderClient.getInstance(
+    this,
+    WRITE_KEY,
+    RudderConfig.Builder()
+        .withDataPlaneUrl(DATA_PLANE_URL)
+        .withTrackLifecycleEvents(true)
+        .withRecordScreenViews(true)
+        .withAutoCollectAdvertId(true)
+        .build()
+)
+```
 
 <div class="warningBlock">
 
@@ -663,15 +675,13 @@ RudderStack collects the advertisement ID **only** if `withAutoCollectAdvertId` 
   </ul>
 </div>
 
-RudderStack sets `gaid` under `context.device.advertisementId`.
-
-### Setting the advertising ID using `putAdvertisingId`
-
 To set your own advertising ID, you can use the `putAdvertisingId` method and pass the advertising ID, as shown:
 
 ```java
 RudderClient.putAdvertisingId(<ADVERTISING_ID>);
 ```
+
+RudderStack sets `gaid` under `context.device.advertisementId`.
 
 ## Anonymous ID
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -159,6 +159,7 @@ val rudderClient = RudderClient.getInstance(
         .withDataPlaneUrl(DATA_PLANE_URL)
         .withTrackLifecycleEvents(true)
         .withRecordScreenViews(true)
+        .withAutoCollectAdvertId(false)
         .build()
 )
 ```
@@ -175,6 +176,7 @@ RudderClient rudderClient = RudderClient.getInstance(
                 .withDataPlaneUrl(DATA_PLANE_URL)
                 .withTrackLifecycleEvents(true)
                 .withRecordScreenViews(true)
+                .withAutoCollectAdvertId(false)
                 .build()
 );
 ```
@@ -583,14 +585,14 @@ You can configure your client based on the following parameters using `RudderCon
 
 | Parameter               | Type      | Description                                                                                                                                                                                                                                       | Default Value                                            |
 | :---------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------- |
-| `logLevel`              | `int`     | Controls how much of the log you want to see from the SDK.                                                                                                                                                                                        | `RudderLogger.RudderLogLevel.NONE`                       |
+| `logLevel`              | `int`     | Controls how much of the log you want to see from the SDK.           | `RudderLogger.RudderLogLevel.NONE`                       |
 | `dataPlaneUrl`          | `string`  | Your data plane URL.                                                             | `https://hosted.rudderlabs.com` |
-| `flushQueueSize`        | `int`     | Number of events in a batch request to the server.                                                                                                                                                                                                | `30`                                                     |
-| `dbThresholdCount`      | `int`     | Number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the DB.                                                                                                                           | `10000`                                                  |
-| `sleepcount`          | `int`     | Minimum waiting time to flush the events to the server. The minimum value can be set to 1 second.                                                                                                                                                                                          | `10 seconds`                                             |
-| `configRefreshInterval` | `int`     | It will fetch the config from `dashboard` after the specified time                                                                                                                                                                                 | `2 hours`                                                      |
+| `flushQueueSize`        | `int`     | Number of events in a batch request to the server.              | `30`                                                     |
+| `dbThresholdCount`      | `int`     | Number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the DB.                          | `10000`                                                  |
+| `sleepcount`          | `int`     | Minimum waiting time to flush the events to the server. The minimum value can be set to 1 second.      | `10 seconds`                                             |
+| `configRefreshInterval` | `int`     | It will fetch the config from `dashboard` after the specified time          | `2 hours`       |
 | `trackLifecycleEvents`  | `boolean` | Whether SDK will capture application life cycle events automatically.                                                                                                                                                                             | `true`                                                   |
-| `recordScreenViews`     | `boolean` | Whether SDK will capture screen view events automatically.                                                                                                                                                                                        | `false`                                                  |
+| `recordScreenViews`     | `boolean` | Whether SDK will capture screen view events automatically.                   | `false`            |
 | `controlPlaneUrl`       | `string`  | This parameter should be changed **only if** you are self-hosting the Control Plane. Check the section **Self-Hosted Control Plane** below for more information. The SDK will add `/sourceConfig` along with this URL to fetch the configuration. | [https://api.rudderlabs.com](https://api.rudderlabs.com) |
 
 A sample code snippet to configure your client using `RudderConfig.Builder` is shown below:
@@ -649,11 +651,22 @@ RudderClient.putDeviceToken("your_device_token");
 
 ## Advertisement ID
 
-We collect the `advertisementId` if it is enabled by the user and the App has the Google Play services Ads SDK embedded in the application. We set the `gaid` under `context.device.advertisementId`.
+RudderStack collects the advertisement ID **only** if `withAutoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client).
 
-Apart from it, if you want to set the `advertisingId` by yourself, you can do so using the `putAdvertisingId` method and passing the `advertisingId`.
+<div class="warningBlock">
 
-An example of setting the `advertisingId` is as below:
+  For RudderStack to collect the advertisement ID, the following conditions must also be met:
+  <ul>
+    <li><code class="inline-code">com.google.android.gms.ads.identifier.AdvertisingIdClient</code> must be present in your application's class path.</li>
+    <li><code class="inline-code">limitAdTracking</code> must not be enabled for your device.</li>
+  </ul>
+</div>
+
+RudderStack sets `gaid` under `context.device.advertisementId`.
+
+### Setting the advertising ID using `putAdvertisingId`
+
+To set your own advertising ID, you can use the `putAdvertisingId` method and pass the advertising ID, as shown:
 
 ```java
 RudderClient.putAdvertisingId(<ADVERTISING_ID>);

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -648,7 +648,7 @@ RudderClient.putDeviceToken("your_device_token");
     </TabPanels>
 </Tabs>
 
-## Setting the advertisement ID using `putAdvertisingId`
+## Setting the advertisement ID
 
 By default, RudderStack collects the advertisement ID **only** if the following three conditions are met:
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -583,17 +583,18 @@ rudderClient.reset();
 
 You can configure your client based on the following parameters using `RudderConfig.Builder`:
 
-| Parameter               | Type      | Description                                                                                                                                                                                                                                       | Default Value                                            |
-| :---------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------- |
-| `logLevel`              | `int`     | Controls how much of the log you want to see from the SDK.           | `RudderLogger.RudderLogLevel.NONE`                       |
-| `dataPlaneUrl`          | `string`  | Your data plane URL.                                                             | `https://hosted.rudderlabs.com` |
-| `flushQueueSize`        | `int`     | Number of events in a batch request to the server.              | `30`                                                     |
-| `dbThresholdCount`      | `int`     | Number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the DB.                          | `10000`                                                  |
-| `sleepcount`          | `int`     | Minimum waiting time to flush the events to the server. The minimum value can be set to 1 second.      | `10 seconds`                                             |
-| `configRefreshInterval` | `int`     | It will fetch the config from `dashboard` after the specified time          | `2 hours`       |
-| `trackLifecycleEvents`  | `boolean` | Whether SDK will capture application life cycle events automatically.                                                                                                                                                                             | `true`                                                   |
-| `recordScreenViews`     | `boolean` | Whether SDK will capture screen view events automatically.                   | `false`            |
-| `controlPlaneUrl`       | `string`  | This parameter should be changed **only if** you are self-hosting the Control Plane. Check the section **Self-Hosted Control Plane** below for more information. The SDK will add `/sourceConfig` along with this URL to fetch the configuration. | [https://api.rudderlabs.com](https://api.rudderlabs.com) |
+| Parameter               | Type      | Description                | Default value                                            |
+| :---------------------- | :-------- | :--------------------- | :------------------------------- |
+| `logLevel`              | Integer     | Controls how much of the log you want to see from the SDK.           | `RudderLogger.RudderLogLevel.NONE`                       |
+| `dataPlaneUrl`          | String  | Your data plane URL.                                                             | `https://hosted.rudderlabs.com` |
+| `flushQueueSize`        | Integer     | Number of events in a batch request to the RudderStack server.              | `30`                                                     |
+| `dbThresholdCount`      | Integer     | Number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the database.                          | `10000`                                                  |
+| `sleepcount`          | Integer     | Minimum waiting time to flush the events to the RudderStack server. The minimum value can be set to 1 second.      | `10 seconds`                                             |
+| `configRefreshInterval` | Integer     | It will fetch the config from `dashboard` after the specified time          | `2 hours`       |
+| `trackLifecycleEvents`  | Boolean | Whether SDK will capture application life cycle events automatically.                     | `true`                                                   |
+| `recordScreenViews`     | Boolean | Whether SDK will capture screen view events automatically.                   | `false`            |
+| `autoCollectAdvertId`  | Boolean | Whether the SDK will collect the advertising ID.  | `false` |
+| `controlPlaneUrl`       | String  | Change this parameter **only if** you are self-hosting the control plane. Check the [Self-hosted control plane](#self-hosted-control-plane) section below for more information. The SDK will add `/sourceConfig` along with this URL to fetch the source configuration. | [https://api.rudderlabs.com](https://api.rudderlabs.com) |
 
 A sample code snippet to configure your client using `RudderConfig.Builder` is shown below:
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
@@ -67,14 +67,8 @@ The `setup` method has the following signature:
 
 <div class="infoBlock">
 <ul>
-<li>
-
-Check the <a href="https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk/#configuring-the-rudderstack-client">Configuring the RudderStack Client</a> section below for detailed information on the parameters you can send in the <code class="inline-code">configuration</code> object.
-</li>
-<li>
-
-Check the <a href="https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk/#configuring-your-options-object">Configuring the options object</a> section below for detailed information on the parameters you can send in the <code class="inline-code">options</code> object.
-</li>
+<li>Check the <a href="#configuring-the-rudderstack-client">Configuring the RudderStack Client</a> section below for detailed information on the parameters you can send in the <code class="inline-code">configuration</code> object.</li>
+<li>Check the <a href="#configuring-the-options-object">Configuring the options object</a> section below for detailed information on the parameters you can send in the <code class="inline-code">options</code> object.</li>
 </ul>
 </div>
 
@@ -90,10 +84,8 @@ You can configure your RudderStack client by passing the following parameters in
 | `dbThresholdCount` | Integer | The number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the database. | `10000` |
 | `sleepTimeout` | Integer | Minimum waiting time to flush the events to the server. | `10 seconds` |
 | `configRefreshInterval` | Integer | RudderStack fetches the config after this time interval. | `2` |
-| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertising ID. | `false` |
-| `trackLifecycleEvents` | Boolean | Determines if the SDK should capture the application life cycle events automatically. | `true` |
-
-
+| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertisement ID. | `false` |
+| `trackLifecycleEvents` | Boolean | Determines if the SDK should capture the application lifecycle events automatically. | `true` |
 
 ## Identify
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
@@ -47,7 +47,8 @@ A sample Cordova SDK initialization is as shown:
 
 ```javascript
 RudderClient.initialize(WRITE_KEY , {
-  dataPlaneUrl: DATA_PLANE_URL
+  dataPlaneUrl: DATA_PLANE_URL,
+  loglevel: RudderClient.LogLevel.VERBOSE,
 })
 ```
 
@@ -76,6 +77,23 @@ Check the <a href="https://rudderstack.com/docs/stream-sources/rudderstack-sdk-i
 </li>
 </ul>
 </div>
+
+## Configuring the RudderStack client
+
+You can configure your RudderStack client by passing the following parameters in the `configuration` object of your `RudderClient.initialize()` call:
+
+| Parameter | Type | Description | Default Value |
+| :--- | :--- | :--- | :--- |
+| `logLevel` | `RudderClient.LogLevel` | Controls how much of the log you want to see from the Cordova SDK. | `RudderClient.LogLevel.None` |
+| `dataPlaneUrl` | String | Your RudderStack Data Plane URL. | [**https://hosted.rudderlabs.com**](https://hosted.rudderlabs.com) |
+| `flushQueueSize` | Integer | The number of events included in a batch request to the server. | `30` |
+| `dbThresholdCount` | Integer | The number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the database. | `10000` |
+| `sleepTimeout` | Integer | Minimum waiting time to flush the events to the server. | `10 seconds` |
+| `configRefreshInterval` | Integer | RudderStack fetches the config after this time interval. | `2` |
+| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertising ID. | `false` |
+| `trackLifecycleEvents` | Boolean | Determines if the SDK should capture the application life cycle events automatically. | `true` |
+
+
 
 ## Identify
 
@@ -277,6 +295,25 @@ A sample `reset` call is as shown:
 RudderClient.reset()
 ```
 
+## Configuring the `options` object
+
+A sample `options` object that can be sent along with all the above-mentioned API calls is as shown:
+
+```javascript
+{
+  "externalIds": {
+    "brazeExternalId": "externalId1"
+  }
+}
+```
+
+The `options` object has the following signature:
+
+| Name | Data Type | Presence | Description |
+| :--- | :--- | :--- | :--- |
+| `externalIds` | `JSON Object` | Optional | Each key within `externalIds` object should define the type of external ID, and its value should be a `String` or `Integer`. |
+| `integrations` | `JSON Object` | Optional | Each key within the `integrations` object should hold the display name of your desired destination. Its value should be a `boolean` indicating whether you want to send that event or not. For more details check the [**Enabling/disabling events for specific destinations**](https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk/#enablingdisabling-events-for-specific-destinations) section below. |
+
 ## Enabling/disabling user tracking via the optOut API \(GDPR support\)
 
 RudderStack gives the users \(e.g., an EU user\) the ability to opt out of tracking any user activity until the user gives their consent. You can do this by leveraging RudderStack's `optOut` API.
@@ -299,39 +336,6 @@ RudderClient.optOut(false);
   
  The <code class="inline-code">optOut</code> API is available in the Cordova SDK starting from version <code class="inline-code">1.0.1</code>. 
 </div>
-
-## Configuring the RudderStack client
-
-You can configure your RudderStack client by passing the following parameters in the `configuration` object of your `RudderClient.initialize()` call:
-
-| Parameter | Type | Description | Default Value |
-| :--- | :--- | :--- | :--- |
-| `logLevel` | `RudderClient.LogLevel` | Controls how much of the log you want to see from the Cordova SDK. | `RudderClient.LogLevel.None` |
-| `dataPlaneUrl` | `string` | Your RudderStack Data Plane URL. | [**https://hosted.rudderlabs.com**](https://hosted.rudderlabs.com) |
-| `flushQueueSize` | `int` | The number of events included in a batch request to the server. | `30` |
-| `dbThresholdCount` | `int` | The number of events to be saved in the `SQLite` database. Once the limit is reached, older events are deleted from the database. | `10000` |
-| `sleepTimeout` | `int` | Minimum waiting time to flush the events to the server. | `10 seconds` |
-| `configRefreshInterval` | `int` | RudderStack fetches the config after this time interval. | `2` |
-| `trackLifecycleEvents` | `boolean` | Determines if the SDK should capture the application life cycle events automatically. | `true` |
-
-## Configuring the `options` object
-
-A sample `options` object that can be sent along with all the above-mentioned API calls is as shown:
-
-```javascript
-{
-  "externalIds": {
-    "brazeExternalId": "externalId1"
-  }
-}
-```
-
-The `options` object has the following signature:
-
-| Name | Data Type | Presence | Description |
-| :--- | :--- | :--- | :--- |
-| `externalIds` | `JSON Object` | Optional | Each key within `externalIds` object should define the type of external ID, and its value should be a `String` or `Integer`. |
-| `integrations` | `JSON Object` | Optional | Each key within the `integrations` object should hold the display name of your desired destination. Its value should be a `boolean` indicating whether you want to send that event or not. For more details check the [**Enabling/disabling events for specific destinations**](https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk/#enablingdisabling-events-for-specific-destinations) section below. |
 
 ## Filtering events
 
@@ -402,14 +406,24 @@ RudderClient.putAnonymousId("CustomAnonymousId");
 
 ## Advertisement ID
 
-RudderStack collects the advertisement ID if it is enabled by the user. To set the advertising ID yourself, you can use the `putAdvertisingId` method as shown:
+RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+
+```javascript
+RudderClient.initialize(WRITE_KEY , {
+  dataPlaneUrl: DATA_PLANE_URL,
+  loglevel: RudderClient.LogLevel.VERBOSE,
+  autoCollectAdvertId: true,
+})
+```
+
+To set the advertising ID yourself, you can use the `putAdvertisingId` method as shown:
 
 ```javascript
 RudderClient.putAdvertisingId("SampleAdvertisingId")
 ```
 <div class="warningBlock">
 
-On iOS, you need to call the <code class="inline-code">putAdvertisingId</code> method before calling <code class="inline-code">initialize</code>.
+In iOS, you need to call the <code class="inline-code">putAdvertisingId</code> method before calling <code class="inline-code">initialize</code>.
 </div>
 
 ## Setting the device token

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
@@ -396,7 +396,7 @@ RudderStack uses the `deviceId` as anonymousId by default. You can use the `putA
 RudderClient.putAnonymousId("CustomAnonymousId");
 ```
 
-## Advertisement ID
+## Setting the advertisement ID
 
 RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
 
@@ -408,7 +408,7 @@ RudderClient.initialize(WRITE_KEY , {
 })
 ```
 
-To set the advertising ID yourself, you can use the `putAdvertisingId` method as shown:
+To set the advertisement ID yourself, you can use the `putAdvertisingId` method as shown:
 
 ```javascript
 RudderClient.putAdvertisingId("SampleAdvertisingId")

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk.mdx
@@ -289,22 +289,54 @@ RudderClient.reset()
 
 ## Configuring the `options` object
 
-A sample `options` object that can be sent along with all the above-mentioned API calls is as shown:
-
-```javascript
-{
-  "externalIds": {
-    "brazeExternalId": "externalId1"
-  }
-}
-```
-
-The `options` object has the following signature:
+The `options` object can be sent along with all the above-mentioned API calls. It has the following signature:
 
 | Name | Data Type | Presence | Description |
 | :--- | :--- | :--- | :--- |
 | `externalIds` | `JSON Object` | Optional | Each key within `externalIds` object should define the type of external ID, and its value should be a `String` or `Integer`. |
 | `integrations` | `JSON Object` | Optional | Each key within the `integrations` object should hold the display name of your desired destination. Its value should be a `boolean` indicating whether you want to send that event or not. For more details check the [**Enabling/disabling events for specific destinations**](https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-cordova-sdk/#enablingdisabling-events-for-specific-destinations) section below. |
+
+A sample `options` object for an `identify` event is as shown:
+
+```javascript
+RudderClient.identify("1hKOmRA4el9Ztm", {
+  "address": {
+    "city": "New Orleans",
+    "country": "USA",
+    "state": "Louisiana",
+  },
+  "birthday": "01/24/1984",
+  "company": {
+    "name": "Apple Inc.",
+    "id": "1hKOmRA4el9Ztm",
+    "industry": "IT"
+  },
+  "email": "alex@example.com",
+  "firstName": "Alex",
+}, {
+  "externalIds": {
+    "brazeExternalId": "externalId1"
+  },
+  "integrations": {
+    "MixPanel": false,
+    "Amplitude": true
+  }
+})
+```
+
+In the above snippet, the `options` object is as follows:
+
+```javascript
+{
+  "externalIds": {
+    "brazeExternalId": "externalId1"
+  },
+  "integrations": {
+    "MixPanel": false,
+    "Amplitude": true
+  }
+}
+```
 
 ## Enabling/disabling user tracking via the optOut API \(GDPR support\)
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/flutter-v2.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/flutter-v2.mdx
@@ -470,7 +470,7 @@ By default, RudderStack uses `deviceId` as `anonymousId`. You can use the follow
 rudderClient.putAnonymousId(<ANONYMOUS_ID>);
 ```
 
-## Setting your advertisement ID
+## Setting the advertisement ID
 
 <div class="infoBlock">
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/flutter-v2.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/flutter-v2.mdx
@@ -125,6 +125,7 @@ You can configure your client based on the following parameters by passing them 
 | `sleepTimeout`          | Integer     | Minimum waiting time to flush the events to the server.          | `10 seconds`                      |
 | `configRefreshInterval` | Integer     | Fetches the config from the dashboard after this specified time.                              | `2`                                                      |
 | `trackLifecycleEvents`  | Boolean | Determines if the SDK will capture application life cycle events automatically.                   | `true`                                                   |
+| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertising ID. | `false` |
 | `recordScreenViews` | Boolean | When enabled, the SDK automatically records the screens viewed by the user. | `false` |
 
 ### webConfig parameters
@@ -469,12 +470,24 @@ By default, RudderStack uses `deviceId` as `anonymousId`. You can use the follow
 rudderClient.putAnonymousId(<ANONYMOUS_ID>);
 ```
 
-## Passing your Android/iOS advertising ID
+## Setting your advertisement ID
 
 <div class="infoBlock">
 
 This functionality is not available for the web. For more information, refer to the <a href="#sdk-api-unavailable-for-web">SDK API unavailable for web</a> section below.
 </div>
+
+RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+
+```dart
+final RudderController rudderClient = RudderController.instance;
+MobileConfig mobileConfig = MobileConfig(autoCollectAdvertId: true);
+RudderLogger.init(RudderLogger.VERBOSE);
+RudderConfigBuilder builder = RudderConfigBuilder();
+builder.withDataPlaneUrl(<DATA_PLANE_URL>);
+builder.withTrackLifecycleEvents(true);
+rudderClient.initialize(<WRITE_KEY>,config: builder.build());
+```
 
 You can use the `putAdvertisingId` method to pass your Android and iOS AAID and IDFA respectively. The `putAdvertisingId` method accepts a string argument as described below:
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/flutter-v2.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/flutter-v2.mdx
@@ -125,7 +125,7 @@ You can configure your client based on the following parameters by passing them 
 | `sleepTimeout`          | Integer     | Minimum waiting time to flush the events to the server.          | `10 seconds`                      |
 | `configRefreshInterval` | Integer     | Fetches the config from the dashboard after this specified time.                              | `2`                                                      |
 | `trackLifecycleEvents`  | Boolean | Determines if the SDK will capture application life cycle events automatically.                   | `true`                                                   |
-| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertising ID. | `false` |
+| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertisement ID. | `false` |
 | `recordScreenViews` | Boolean | When enabled, the SDK automatically records the screens viewed by the user. | `false` |
 
 ### webConfig parameters

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/index.mdx
@@ -418,7 +418,7 @@ By default, RudderStack uses `deviceId` as `anonymousId`. You can use the follow
 rudderClient.putAnonymousId(<ANONYMOUS_ID>);
 ```
 
-## Setting your advertisement ID
+## Setting the advertisement ID
 
 RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/index.mdx
@@ -111,6 +111,7 @@ You can configure your client based on the following parameters by passing them 
 | `sleepTimeout`          | Integer     | Minimum waiting time to flush the events to the server.                                                                                                                                                                                           | `10 seconds`                                             |
 | `configRefreshInterval` | Integer     | Fetches the config from the dashboard after this specified time.                                                      | `2`                                                      |
 | `trackLifecycleEvents`  | Boolean | Determines if the SDK will capture application life cycle events automatically.                                     | `true`                                                   |
+| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertising ID. | `false` |
 | `controlPlaneUrl`       | String  | This parameter should be changed **only if** you are self-hosting the control plane. Check the section [Self-hosted control plane](#self-hosted-control-plane) section below for more information. The SDK will add `/sourceConfig` along with this URL to fetch the configuration. | `https://api.rudderlabs.com` |
 
 ## Identify
@@ -417,13 +418,27 @@ By default, RudderStack uses `deviceId` as `anonymousId`. You can use the follow
 rudderClient.putAnonymousId(<ANONYMOUS_ID>);
 ```
 
-## Passing your Android/iOS advertising ID
+## Setting your advertisement ID
 
-You can use the `putAdvertisingId` method to pass your Android and iOS AAID and IDFA respectively. The `putAdvertisingId` method accepts a string argument as described below:
+RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+
+```dart
+final RudderController rudderClient = RudderController.instance;
+MobileConfig mobileConfig = MobileConfig(autoCollectAdvertId: true);
+RudderLogger.init(RudderLogger.VERBOSE);
+RudderConfigBuilder builder = RudderConfigBuilder();
+builder.withDataPlaneUrl(<DATA_PLANE_URL>);
+builder.withTrackLifecycleEvents(true);
+rudderClient.initialize(<WRITE_KEY>,config: builder.build());
+```
+
+You can use the `putAdvertisingId` method to pass your Android and iOS AAID and IDFA respectively. 
+
+The `putAdvertisingId` method accepts a string argument as listed below:
 
 - `id` : Your Android `advertisingId` \(AAID\) \(or\) your iOS `advertisingId` \(IDFA\).
 
-An example of how to use `putAdvertisingId` is as shown:
+The following snippet highlights the use of `putAdvertisingId()`:
 
 ```dart
 rudderClient.putAdvertisingId(<ADVERTISING_ID>);

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-flutter-sdk/index.mdx
@@ -111,7 +111,7 @@ You can configure your client based on the following parameters by passing them 
 | `sleepTimeout`          | Integer     | Minimum waiting time to flush the events to the server.                                                                                                                                                                                           | `10 seconds`                                             |
 | `configRefreshInterval` | Integer     | Fetches the config from the dashboard after this specified time.                                                      | `2`                                                      |
 | `trackLifecycleEvents`  | Boolean | Determines if the SDK will capture application life cycle events automatically.                                     | `true`                                                   |
-| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertising ID. | `false` |
+| `autoCollectAdvertId` | Boolean | Determines if the SDK will collect the advertisement ID. | `false` |
 | `controlPlaneUrl`       | String  | This parameter should be changed **only if** you are self-hosting the control plane. Check the section [Self-hosted control plane](#self-hosted-control-plane) section below for more information. The SDK will add `/sourceConfig` along with this URL to fetch the configuration. | `https://api.rudderlabs.com` |
 
 ## Identify
@@ -436,7 +436,7 @@ You can use the `putAdvertisingId` method to pass your Android and iOS AAID and 
 
 The `putAdvertisingId` method accepts a string argument as listed below:
 
-- `id` : Your Android `advertisingId` \(AAID\) \(or\) your iOS `advertisingId` \(IDFA\).
+- `id` : Your Android advertisement ID (AAID) or your iOS advertisement ID (IDFA).
 
 The following snippet highlights the use of `putAdvertisingId()`:
 
@@ -446,7 +446,7 @@ rudderClient.putAdvertisingId(<ADVERTISING_ID>);
 
 <div class="infoBlock">
 
-  The <code class="inline-code">id</code> parameter that you pass in the <code class="inline-code">putAdvertisingId</code> method is assigned as the AAID if you are on an Android device, and as the IDFA if you are on an iOS device.
+  The <code class="inline-code">id</code> parameter that you pass in the <code class="inline-code">putAdvertisingId</code> method is assigned as the AAID (for Android) or as the IDFA (for iOS).
 </div>
 
 ## Setting the device token
@@ -484,8 +484,7 @@ import 'package:rudder_sdk_flutter/RudderLogger.dart';
 RudderConfigBuilder builder = RudderConfigBuilder();
 builder.withDataPlaneUrl(DATA_PLANE_URL);
 builder.withLogLevel(RudderLogger.VERBOSE);
-rudderClient.initialize(WRITE_KEY,
-                          config: builder.build());
+rudderClient.initialize(WRITE_KEY,config: builder.build());
 ```
 
 You can set the log level to one of the following values:

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk.mdx
@@ -219,6 +219,20 @@ You can configure your client based on the following parameters by passing them 
     </tr>
     <tr>
       <td style="text-align:left">
+        <code class="inline-code">autoCollectAdvertId</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">Boolean</code>
+      </td>
+      <td style="text-align:left">
+        Determines if the SDK will collect the advertisement ID.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">false</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
         <code class="inline-code">recordScreenViews</code>
       </td>
       <td style="text-align:left">
@@ -508,13 +522,11 @@ const options = {
 <div class="infoBlock">
 
 The keyword <code class="inline-code">All</code> in the above snippet represents all the destinations the source is connected to. Its value is set to <code class="inline-code">true</code> by default.
-
 </div>
 
 <div class="infoBlock">
 
 Make sure the destination names that you pass while specifying the destinations should exactly match the names listed <a href="https://app.rudderstack.com/directory">here</a>.
-
 </div>
 
 There are two methods in which you can pass the destinations specified in the above snippet to the SDK:
@@ -599,7 +611,7 @@ You can set the log level to one of the following values:
 5. `DEBUG`
 6. `VERBOSE`
 
-## Advertising ID
+## Setting the advertisement ID using `putAdvertisingId`
 
 RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
 
@@ -617,7 +629,7 @@ You can use the `putAdvertisingId` method to pass your Android and iOS AAID and 
 - `androidId` : Your Android `advertisingId` \(AAID\)
 - `iOSId` : Your iOS `advertisingId` \(IDFA\)
 
-Example Usage:
+A sample snippet highlighting the use of `putAdvertisingId` is shown below:
 
 ```typescript
 rudderClient.putAdvertisingId(AAID, IDFA)

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk.mdx
@@ -97,7 +97,183 @@ The `setup` method has the following signature:
 | `writeKey`      | String     | Yes      | Your React Native source write key                  |
 | `configuration` | Object | No       | Contains the RudderStack client configuration |
 
-Check the [**Configuring your RudderStack client**](https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk/#configuring-your-rudderstack-client) section below for a full list of configurable parameters.
+Check the [Configuring your RudderStack client](#configuring-your-rudderstack-client) section below for a full list of configurable parameters.
+
+## Configuring your RudderStack client
+
+You can configure your client based on the following parameters by passing them in the `configuration` object of your `setup` call.
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align:left">Parameter</th>
+      <th style="text-align:left">Type</th>
+      <th style="text-align:left">Description</th>
+      <th style="text-align:left">Default value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">logLevel</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">int</code>
+      </td>
+      <td style="text-align:left">
+        <p>Controls how much of the log you want to see from the SDK.</p>
+        <p>
+          Refer to the <a href="#debugging">Debugging</a> section to get a list of all supported values.
+        </p>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">RUDDER_LOG_LEVEL.ERROR</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">dataPlaneUrl</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">string</code>
+      </td>
+      <td style="text-align:left">
+        URL of your <code class="inline-code">data-plane</code>. Please refer above to see how to
+        fetch the data plane URL.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">https://hosted.rudderlabs.com</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">flushQueueSize</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">int</code>
+      </td>
+      <td style="text-align:left">
+        Number of events in a batch request to the server.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">30</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">dbThresholdCount</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">int</code>
+      </td>
+      <td style="text-align:left">
+        The number of events to be saved in the <code class="inline-code">SQLite</code> database.
+        Once the limit is reached, older events are deleted from the DB.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">10000</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">sleepTimeout</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">int</code>
+      </td>
+      <td style="text-align:left">
+        Minimum waiting time to flush the events to the server.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">10 seconds</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">configRefreshInterval</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">int</code>
+      </td>
+      <td style="text-align:left">
+        It will fetch the config from <code class="inline-code">dashboard</code> after this many
+        hours.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">2</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">trackLifecycleEvents</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">boolean</code>
+      </td>
+      <td style="text-align:left">
+        Whether SDK will capture application life cycle events automatically.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">true</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">recordScreenViews</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">boolean</code>
+      </td>
+      <td style="text-align:left">
+        Whether SDK will capture screen view events automatically.
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">false</code>
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align:left">
+        <code class="inline-code">controlPlaneUrl</code>
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">string</code>
+      </td>
+      <td style="text-align:left">
+        If you are using our open-source <a href="https://rudderstack.com/docs/get-started/control-plane-lite/"><b>Control Plane Lite</b></a> utility, use this option to
+        point to your hosted <code class="inline-code">sourceConfig</code>. SDK will add
+        <code class="inline-code">/sourceConfig</code> along with this URL
+      </td>
+      <td style="text-align:left">
+        <code class="inline-code">https://api.rudderlabs.com</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Identify
+
+RudderStack captures the `deviceId` and uses it as the `anonymousId` for identifying the user. This helps in tracking the users across the application installation. To attach more information to the user, you can use the `identify` method. Once you set the `identify` information to the user, the SDK persists the user information and passes it to the subsequent `track` or `screen` calls. To reset the user identification, you can use the `reset` method.
+
+A sample `identify` event is as shown:
+
+```typescript
+rudderClient.identify(
+  "test_userId",
+  {
+    email: "testuser@example.com",
+    location: "UK",
+  },
+  null
+)
+```
+
+The `identify` method has the following signature:
+
+| Name     | Data Type     | Required | Description                            |
+| :------- | :------------ | :------- | :------------------------------------- |
+| `userId` | String    | Yes      | The user's unique identifier        |
+| `traits` | Object | No       | Traits information for the user            |
+| `option` | Object | No       | Extra options for the `identify` event |
 
 ## Track
 
@@ -133,31 +309,6 @@ RudderStack automatically tracks the following optional events:
 </ol>
 You can disable these events by passing <code class="inline-code">trackLifecycleEvents</code> as <code class="inline-code">false</code> in the configuration object. However, we recommend keeping them enabled.
 </div>
-
-## Identify
-
-RudderStack captures the `deviceId` and uses it as the `anonymousId` for identifying the user. This helps in tracking the users across the application installation. To attach more information to the user, you can use the `identify` method. Once you set the `identify` information to the user, the SDK persists the user information and passes it to the subsequent `track` or `screen` calls. To reset the user identification, you can use the `reset` method.
-
-A sample `identify` event is as shown:
-
-```typescript
-rudderClient.identify(
-  "test_userId",
-  {
-    email: "testuser@example.com",
-    location: "UK",
-  },
-  null
-)
-```
-
-The `identify` method has the following signature:
-
-| Name     | Data Type     | Required | Description                            |
-| :------- | :------------ | :------- | :------------------------------------- |
-| `userId` | String    | Yes      | The user's unique identifier        |
-| `traits` | Object | No       | Traits information for the user            |
-| `option` | Object | No       | Extra options for the `identify` event |
 
 ## Screen
 
@@ -418,157 +569,6 @@ rudderClient.identify(
 )
 ```
 
-## Configuring your RudderStack client
-
-You can configure your client based on the following parameters by passing them in the `configuration` object of your `setup` call.
-
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left">Parameter</th>
-      <th style="text-align:left">Type</th>
-      <th style="text-align:left">Description</th>
-      <th style="text-align:left">Default Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">logLevel</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">int</code>
-      </td>
-      <td style="text-align:left">
-        <p>Controls how much of the log you want to see from the SDK.</p>
-        <p>
-          Refer to the Debugging section to get a list of all supported values.
-        </p>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">RUDDER_LOG_LEVEL.ERROR</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">dataPlaneUrl</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">string</code>
-      </td>
-      <td style="text-align:left">
-        URL of your <code class="inline-code">data-plane</code>. Please refer above to see how to
-        fetch the data plane URL.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">https://hosted.rudderlabs.com</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">flushQueueSize</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">int</code>
-      </td>
-      <td style="text-align:left">
-        Number of events in a batch request to the server.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">30</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">dbThresholdCount</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">int</code>
-      </td>
-      <td style="text-align:left">
-        The number of events to be saved in the <code class="inline-code">SQLite</code> database.
-        Once the limit is reached, older events are deleted from the DB.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">10000</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">sleepTimeout</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">int</code>
-      </td>
-      <td style="text-align:left">
-        Minimum waiting time to flush the events to the server.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">10 seconds</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">configRefreshInterval</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">int</code>
-      </td>
-      <td style="text-align:left">
-        It will fetch the config from <code class="inline-code">dashboard</code> after this many
-        hours.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">2</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">trackLifecycleEvents</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">boolean</code>
-      </td>
-      <td style="text-align:left">
-        Whether SDK will capture application life cycle events automatically.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">true</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">recordScreenViews</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">boolean</code>
-      </td>
-      <td style="text-align:left">
-        Whether SDK will capture screen view events automatically.
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">false</code>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">
-        <code class="inline-code">controlPlaneUrl</code>
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">string</code>
-      </td>
-      <td style="text-align:left">
-        If you are using our open-source <a href="https://rudderstack.com/docs/get-started/control-plane-lite/"><b>Control Plane Lite</b></a> utility, use this option to
-        point to your hosted <code class="inline-code">sourceConfig</code>. SDK will add
-        <code class="inline-code">/sourceConfig</code> along with this URL
-      </td>
-      <td style="text-align:left">
-        <code class="inline-code">https://api.rudderlabs.com</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## Debugging
 
 If you run into any issues regarding the RudderStack React Native SDK, you can turn on the `VERBOSE` or `DEBUG` logging to find out what the issue is.
@@ -600,6 +600,17 @@ You can set the log level to one of the following values:
 6. `VERBOSE`
 
 ## Advertising ID
+
+RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+
+```typescript
+await rudderClient.setup(WRITE_KEY, {
+  dataPlaneUrl: DATA_PLANE_URL,
+  trackLifecycleEvents: true,
+  autoCollectAdvertId: true,
+  recordScreenViews: true,
+})
+```
 
 You can use the `putAdvertisingId` method to pass your Android and iOS AAID and IDFA respectively. The `putAdvertisingId` method accepts two `string` arguments :
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-react-native-sdk.mdx
@@ -611,7 +611,7 @@ You can set the log level to one of the following values:
 5. `DEBUG`
 6. `VERBOSE`
 
-## Setting the advertisement ID using `putAdvertisingId`
+## Setting the advertisement ID
 
 RudderStack collects the advertisement ID **only** if `autoCollectAdvertId` is set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
 

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-unity-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-unity-sdk.mdx
@@ -62,6 +62,7 @@ RudderClient.SerializeSqlite();
 // Build your config
 RudderConfigBuilder configBuilder = new RudderConfigBuilder()
     .WithDataPlaneUrl(DATA_PLANE_URL);
+    .WithLogLevel(RudderLogLevel.VERBOSE)
 
 // get instance for RudderClient
 RudderClient rudderClient = RudderClient.GetInstance(
@@ -169,6 +170,17 @@ You can find the following files in the **Plugins** folder for the SDK:
 
 - `Plugins/Android/unity-plugin-release.aar`
 - `Plugins/iOS/RudderSDKUnity`
+
+## Advertisement ID 
+
+RudderStack collects the advertisement ID **only** if `withAutoCollectAdvertId` is explicitly set to `true` during the [SDK initialization](#initializing-the-rudderstack-client), as shown:
+
+```csharp
+RudderConfigBuilder configBuilder = new RudderConfigBuilder()
+    .WithDataPlaneUrl(DATA_PLANE_URL);
+    .WithLogLevel(RudderLogLevel.VERBOSE)
+    .withAutoCollectAdvertId(true);
+```
 
 ## Contact us
 


### PR DESCRIPTION
## Description of the change

> Added documentation for `withAutoCollectAdvertId` / `autoCollectAdvertId` for Android, Unity, React Native, Cordova, and Flutter docs.

## Type of documentation
- [ ] New documentation
- [ ] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Mobile SDK configuration for Advertising ID](https://www.notion.so/rudderstacks/Mobile-SDK-s-Configuration-for-Advertising-Id-8636b98c99df4873a6667374d2f1d0d5)