### PR TITLE
Tracking Plans documentation update

### DIFF
--- a/data-governance/tracking-plans/index.mdx
+++ b/data-governance/tracking-plans/index.mdx
@@ -9,6 +9,11 @@ description: >-
 
 Tracking Plans let you proactively monitor and act on non-compliant event data coming into your RudderStack sources based on predefined plans. This can help you prevent or de-risk situations where missing or improperly configured event data can break your downstream destinations.
 
+<div class="infoBlock">
+  
+  The Tracking Plans currently support only <a href="https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/" target="_blank"><code class="inline-code">track</code></a> events.
+</div>
+
 ## Tracking Plan features
 
 With the help of a Tracking Plan, you can:


### PR DESCRIPTION
## Description of the change

> Added a note at the start explicitly mentioning support for only `track` events.

## Type of documentation
- [ ] New documentation
- [ ] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Tracking Plans docs: Specify support for only track events](https://www.notion.so/rudderstacks/Tracking-Plans-docs-Specify-support-for-only-track-events-e44b15a602af4b4995152d95689d0a80)