### PR TITLE
Fix Mailchimp example casing

### DIFF
--- a/destinations/marketing/mailchimp.mdx
+++ b/destinations/marketing/mailchimp.mdx
@@ -107,7 +107,7 @@ rudderanalytics.identify(
   },
   {
     integrations: {
-      MailChimp: {
+      Mailchimp: {
         listId: "esf1rd234a"
       }
     }
@@ -131,7 +131,7 @@ rudderanalytics.identify(
   },
   {
     integrations: {
-      MailChimp: {
+      Mailchimp: {
         subscriptionStatus: "unsubscribed"
       }
     }


### PR DESCRIPTION
## Description of the change

Mailchimp casing is wrong in the examples

## Type of documentation

- [ ] New documentation
- [X] Documentation update
- [ ] Bug fix
