### PR TITLE
Destination name fix in JS SDK

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/index.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/index.mdx
@@ -760,7 +760,7 @@ The following table lists some of the popular destinations along with their supp
 | Salesforce           | `Salesforce`               |
 | Autopilot            | `Autopilot`                |
 | Heap.io              | `Heap.io`                  |
-| Mailchimp            | `Mailchimp`                |
+| Mailchimp            | `MailChimp`                |
 | Redshift             | `Redshift`                 |
 | BigQuery             | `BigQuery`                 |
 | Google Cloud Storage | `Google Cloud Storage`     |


### PR DESCRIPTION
## Description of the change

> Corrected name for the Mailchimp destination to align with the reference in the transformer code.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Bug fix
