### PR TITLE
Tracking Plans update

### DIFF
--- a/data-governance/tracking-plans/index.mdx
+++ b/data-governance/tracking-plans/index.mdx
@@ -11,7 +11,8 @@ Tracking Plans let you proactively monitor and act on non-compliant event data c
 
 <div class="warningBlock">
   
-The Tracking Plans currently support only <a href="https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/" target="_blank"><code class="inline-code">track</code></a> events and are applicable only for <strong>warehouse destinations</strong>.
+
+The Tracking Plans are supported only for the <a href="https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/"><code class="inline-code">track</code></a> events sent to the <strong>warehouse destinations</strong>.
 </div>
 
 ## Tracking Plan features

--- a/data-governance/tracking-plans/index.mdx
+++ b/data-governance/tracking-plans/index.mdx
@@ -9,9 +9,9 @@ description: >-
 
 Tracking Plans let you proactively monitor and act on non-compliant event data coming into your RudderStack sources based on predefined plans. This can help you prevent or de-risk situations where missing or improperly configured event data can break your downstream destinations.
 
-<div class="infoBlock">
+<div class="warningBlock">
   
-  The Tracking Plans currently support only <a href="https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/" target="_blank"><code class="inline-code">track</code></a> events.
+The Tracking Plans currently support only <a href="https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/" target="_blank"><code class="inline-code">track</code></a> events and are applicable only for <strong>warehouse destinations</strong>.
 </div>
 
 ## Tracking Plan features

--- a/data-governance/tracking-plans/index.mdx
+++ b/data-governance/tracking-plans/index.mdx
@@ -12,7 +12,7 @@ Tracking Plans let you proactively monitor and act on non-compliant event data c
 <div class="warningBlock">
   
 
-The Tracking Plans are supported only for the <a href="https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/"><code class="inline-code">track</code></a> events sent to the <strong>warehouse destinations</strong>.
+The Tracking Plans currently support only the <a href="https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/"><code class="inline-code">track</code></a> events sent to the <strong>warehouse destinations</strong>.
 </div>
 
 ## Tracking Plan features

--- a/data-governance/tracking-plans/index.mdx
+++ b/data-governance/tracking-plans/index.mdx
@@ -83,7 +83,7 @@ The Tracking Plans feature currently supports only [`track`](https://www.rudders
 
 ### Are the Tracking Plans supported for all the destinations?
 
-No - the Tracking Plans feature is currently supported only for the [warehouse destinations](https://rudderstack.com/docs/data-warehouse-integrations/)
+No - the Tracking Plans feature is currently supported only for the [warehouse destinations](https://rudderstack.com/docs/data-warehouse-integrations/).
 
 ## Contact us
 

--- a/data-governance/tracking-plans/index.mdx
+++ b/data-governance/tracking-plans/index.mdx
@@ -74,6 +74,16 @@ The Tracking Plans documentation is divided into the following sections:
     </a>
 </div>
 
+## FAQ
+
+### Which calls are supported for the RudderStack Tracking Plans?
+
+The Tracking Plans feature currently supports only [`track`](https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/track/) events.
+
+### Are the Tracking Plans supported for all the destinations?
+
+No - the Tracking Plans feature is currently supported only for the [warehouse destinations](https://rudderstack.com/docs/data-warehouse-integrations/)
+
 ## Contact us
 
 For queries on any of the sections covered in this guide, you can [**contact us**](mailto:%20docs@rudderstack.com) or get in touch with your Account Manager.

--- a/rudderstack-cloud/dashboard-overview.mdx
+++ b/rudderstack-cloud/dashboard-overview.mdx
@@ -117,7 +117,7 @@ Refer to the <a href="https://rudderstack.com/docs/rudderstack-cloud/audit-logs/
 
 <div class="infoBlock">
 
-Refer to the <a href="rudderstack.com/docs/data-governance/tracking-plans/">Tracking Plans</a> guide for more information on creating and using tracking plans in RudderStack.
+Refer to the <a href="https://rudderstack.com/docs/data-governance/tracking-plans/">Tracking Plans</a> guide for more information on creating and using tracking plans in RudderStack.
 </div>
 
 ## Settings


### PR DESCRIPTION
## Description of the change

> Added information on warehouse destinations support for Tracking Plans.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Document: Tracking plans are currently for Warehouse destinations](https://www.notion.so/rudderstacks/Document-Tracking-plans-are-currently-for-Warehouse-destinations-8a8a865f4b064d15a9e314003496914e)