### PR TITLE
JS SDK Quick Start Guide update

### DIFF
--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/quick-start-guide.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/quick-start-guide.mdx
@@ -27,13 +27,8 @@ The above snippet lets you integrate the SDK with your website and load it async
 </div>
 
 <div class="infoBlock">
-  
-  When the SDK is loaded asynchronously, all the API calls should follow only after the <code class="inline-code">load</code> call.        
-</div>
 
-<div class="infoBlock">
-
-To load <code class="inline-code">rudder-analytics.js</code> on to your page synchronously, refer to the **minified** or **non-minified** versions of the snippet below.
+To load <code class="inline-code">rudder-analytics.js</code> on to your page synchronously, refer to the <a href="#minified-code">minified</a> or <a href="#non-minified-code">non-minified</a> versions of the snippet below.
 </div>
 
 The above code snippet does the following:
@@ -62,7 +57,7 @@ rudderanalytics=window.rudderanalytics=[];for(var methods=["load","page","track"
 <script src="https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js"></script>
 ```
 
-### Non-Minified code
+### Non-minified code
 
 ```javascript
 <script>


### PR DESCRIPTION
## Description of the change

> Removed info block and some minor cosmetic tweaks.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Remove info block in QSG: JS SDK](https://www.notion.so/rudderstacks/Remove-info-block-in-quick-start-guide-JS-SDK-6d462f9be51447a986199948362c347e)