### PR TITLE
Application Lifecycle Events Hotfix

### DIFF
--- a/rudderstack-api/api-specification/application-lifecycle-events-spec.mdx
+++ b/rudderstack-api/api-specification/application-lifecycle-events-spec.mdx
@@ -9,6 +9,11 @@ description: >-
 
 RudderStack lets you track various application lifecycle events across the mobile SDKs and get insights into app-related metrics like installs, opens, etc. This guide provides the details and semantic definitions of these events and the associated properties.
 
+<div class="warningBlock">
+
+The Unity SDK currently does not support tracking the application lifecycle events on the Android platform.
+</div>
+
 ## Supported lifecycle events
 
 RudderStack **automatically tracks** the following application lifecycle events:
@@ -100,7 +105,7 @@ There are some differences in the way the RudderStack SDKs handle the above even
 
 | Platform | Expected behavior |
 | :--------| :---|
-| Android | Same behavior as the [Android SDK](#android-sdk). | 
+| Android | **Currently not supported**. | 
 | iOS | Same behavior as the [iOS SDK](#ios-sdk). |
 
 ### React Native SDK

--- a/stream-sources/rudderstack-sdk-integration-guides/rudderstack-unity-sdk.mdx
+++ b/stream-sources/rudderstack-sdk-integration-guides/rudderstack-unity-sdk.mdx
@@ -12,6 +12,11 @@ The **RudderStack Unity SDK** is a wrapper for the RudderStack [**Android SDK**]
 
 Check the [**GitHub codebase**](https://github.com/rudderlabs/rudder-sdk-unity) to get a more hands-on understanding of the SDK.
 
+<div class="warningBlock">
+
+The Unity SDK currently does not support tracking the <a href="https://www.rudderstack.com/docs/rudderstack-api/api-specification/application-lifecycle-events-spec/">application lifecycle events</a> on the Android platform.
+</div>
+
 ## SDK setup requirements
 
 To configure the Unity SDK, you will need the following:


### PR DESCRIPTION
## Description of the change

> Added note mentioning Unity SDK doesn't support the Android platform for tracking app lifecycle events.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Application Lifecycle documentation update](https://www.notion.so/rudderstacks/Application-Lifecycle-documentation-update-47ab99f7eb9944e68a279375015bd7ba)