### PR TITLE
Regulation API documentation updates

### DIFF
--- a/rudderstack-api/data-regulation-api.mdx
+++ b/rudderstack-api/data-regulation-api.mdx
@@ -13,7 +13,7 @@ This guide covers the data regulation feature in detail and details the Data Reg
 
 <div class="warningBlock">
 
-The Data Regulation API is applicable only for the destinations that support events sent via the <a href="https://www.rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/#cloud-mode">RudderStack cloud mode</a>.
+The Data Regulation API is applicable only for the destinations configured to sent events using the <a href="https://www.rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/#cloud-mode">RudderStack cloud mode</a>.
 </div>
 
 <a href="https://rudderstack.com/enterprise-quote" target="_blank">

--- a/rudderstack-api/data-regulation-api.mdx
+++ b/rudderstack-api/data-regulation-api.mdx
@@ -11,6 +11,11 @@ RudderStack's Data Regulation API lets you specify regulations to suspend data c
 
 This guide covers the data regulation feature in detail and details the Data Regulation API endpoints.
 
+<div class="warningBlock">
+
+The Data Regulation API is applicable only for the destinations that support events sent via the <a href="https://www.rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/#cloud-mode">RudderStack cloud mode</a>.
+</div>
+
 <a href="https://rudderstack.com/enterprise-quote" target="_blank">
 <img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" alt="Github Badge" class="githubBadge" />
 </a>
@@ -92,6 +97,18 @@ https://api.rudderstack.com/v2/regulations
   }]
 }
 ```
+
+<div class="infoBlock">
+
+RudderStack supports the <code class="inline-code">suppress_with_delete</code> request for the following destinations:
+<ul>
+  <li><a href="https://www.rudderstack.com/docs/destinations/analytics/amplitude/">Amplitude</a></li>
+  <li><a href="https://www.rudderstack.com/docs/destinations/marketing/braze/">Braze</a></li>
+  <li><a href="https://www.rudderstack.com/docs/destinations/business-messaging/intercom/">Intercom</a></li>
+  <li><a href="https://www.rudderstack.com/docs/destinations/storage-platforms/amazon-s3/">S3</a></li>
+  <li><a href="https://www.rudderstack.com/docs/destinations/storage-platforms/redis/">Redis</a></li>
+</ul>
+</div>
 
 ### `regulationType`
 


### PR DESCRIPTION
## Description of the change

> Specified cloud mode destinations support and added list of destinations supported for `suppress_with_delete` request.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Data Regulation API doc updates](https://www.notion.so/rudderstacks/Data-Regulation-API-documentation-update-4fccbb22cb114219b0f337bc232ff8ed)