### PR TITLE
BigQuery Update -  Deduplication Information

### DIFF
--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -187,7 +187,7 @@ Users can modify the view query to change the time window of the view. The defau
 
 ### Deduplication method
 
-In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables. To enable this method, set the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your open source RudderStack setup to `true`.
+In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables. To enable this method, set the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your RudderStack setup to `true`.
 
 <div class="warningBlock">
 

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -131,7 +131,7 @@ Enter the following credentials in the **Connection Credentials** page:
   - **Sync Starting At**: This optional setting lets you specify the particular time of the day (in UTC) when you want RudderStack to sync the data to BigQuery.
   - **Exclude Window**: This optional setting lets you set a time window when RudderStack will **not sync** the data to your database.
 
-## Schema, partitioned tables, and views
+## Schema, partitioned tables, views, and deduplication
 
 RudderStack uses the source name (written in snake case, for example, `source_name`) to create a dataset in BigQuery.
 
@@ -140,14 +140,33 @@ RudderStack uses the source name (written in snake case, for example, `source_na
 For more details on the tables and columns created by RudderStack, refer to the <a href="https://rudderstack.com/docs/data-warehouse-integrations/warehouse-schemas/">Warehouse Schema</a> guide.
 </div>
 
+RudderStack supports two modes by which data is ingested into BigQuery, driven by the configuration variable `warehouse.bigquery.isDedupEnabled`:
+
+| Ingestion method | `isDedupEnabled`  |
+| :-----------------| :-------------------|
+| Partition (default) | `False` |
+| Deduplication | `True` |
+
+<div class="infoBlock">
+
+By default, deduplication is disabled by RudderStack.
+</div>
+
+### Partitioned tables and views
+
 RudderStack creates ingestion-time partition tables based on the load date, so you can take advantage of it to query a subset of data.
 
 <div class="infoBlock">
 
-More details on the BigQuery partitioned tables can be found in this <a href="https://cloud.google.com/bigquery/docs/partitioned-tables">BigQuery documentation</a>. Information on how RudderStack creates these tables on load can be found in <a href="https://cloud.google.com/bigquery/docs/creating-partitioned-tables#creating_an_ingestion-time_partitioned_table_when_loading_data">this section</a>.
+More details on the BigQuery partitioned tables can be found in this <a href="https://cloud.google.com/bigquery/docs/partitioned-tables">BigQuery documentation</a>. More information on how RudderStack creates these tables on load can be found in <a href="https://cloud.google.com/bigquery/docs/creating-partitioned-tables#creating_an_ingestion-time_partitioned_table_when_loading_data">this section</a>.
 </div>
 
-In addition to tables, a **view** \(`<table_name>_view`\) is created for every table for de-duplication purposes.
+<div class="warningBlock">
+
+Duplicate data is <strong>not</strong> discarded when loading it into BigQuery.
+</div>
+
+In addition to tables, RudderStack creates a **view** \(`<table_name>_view`\) for every table for de-duplication purposes.
 
 <div class="infoBlock">
 
@@ -160,6 +179,25 @@ It is highly recommended that you use the corresponding view \(containing the ev
 
 Users can modify the view query to change the time window of the view. The default value is set to <strong>60 days</strong>.
 </div>
+
+### Deduplication method
+
+In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables.
+
+<div class="warningBlock">
+
+Views will not be created for the tables if you choose the deduplication method.
+</div>
+
+### Switching from deduplication to partitioned tables
+
+You can easily switch from using the deduplication method to ingest your data in BigQuery to the partitioned tables by setting the config parameter `warehouse.bigquery.isDedupEnabled` to `false`.
+
+RudderStack then does the following:
+
+- Creates `users_view` while loading the `users` table.
+- Creates the views for the new `track` events.
+- All the skipped views will be untouched, that is, left as is. You can either create those views or [contact us](mailto:%20support@rudderstack.com).
 
 ## FAQs
 

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -150,7 +150,7 @@ RudderStack supports two modes by which data is ingested into BigQuery:
 By default, RudderStack uses the partitioned tables method to ingest data into BigQuery. Deduplication is disabled.
 </div>
 
-If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source) or are hosting the RudderStack data plane, you can manage these modes via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`, as shown in the following table:
+If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source) or hosting the RudderStack data plane, you can manage these modes via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`, as shown in the following table:
 
 | Ingestion method | `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`  |
 | :-----------------| :-------------------|

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -163,7 +163,7 @@ RudderStack creates ingestion-time partition tables based on the load date, so y
 
 <div class="infoBlock">
 
-More details on the BigQuery partitioned tables can be found in this <a href="https://cloud.google.com/bigquery/docs/partitioned-tables">BigQuery documentation</a>. More information on how RudderStack creates these tables on load can be found in <a href="https://cloud.google.com/bigquery/docs/creating-partitioned-tables#creating_an_ingestion-time_partitioned_table_when_loading_data">this section</a>.
+You can find more details on the BigQuery partitioned tables in <a href="https://cloud.google.com/bigquery/docs/partitioned-tables">BigQuery documentation</a>. For information on how RudderStack creates these tables on load, refer to the <a href="https://cloud.google.com/bigquery/docs/creating-partitioned-tables#creating_an_ingestion-time_partitioned_table_when_loading_data">Creating partitioned tables</a> section of the BigQuery documentation.
 </div>
 
 <div class="warningBlock">
@@ -196,7 +196,7 @@ Views will not be created for the tables if you choose the deduplication method.
 
 <div class="warningBlock">
 
-Note that the <strong>querying cost will increase</strong> if you choose this method, as RudderStack removes the duplicates from the tables through sequential scans that happen on every warehouse upload. For example, if your warehouse upload frequency is set to  every 30 minutes, RudderStack performs a full scan on the <code class="inline-code">tracks</code> table every 30mins to upload any new events.
+Note that the <strong>querying cost will increase</strong> if you choose this method, as RudderStack removes the duplicates from the tables through sequential scans that happen on every warehouse upload. For example, if your warehouse upload frequency is set to  every 30 minutes, RudderStack performs a full scan on the <code class="inline-code">tracks</code> table every 30 minutes to upload any new events.
 </div>
 
 ### Switching from deduplication to partitioned tables
@@ -207,7 +207,7 @@ RudderStack then does the following:
 
 - Creates `users_view` while loading the `users` table, **if not already present**.
 - Creates the views for the new `track` events.
-- All the other skipped views are not regenerated. You can either manually create those views or [contact us](mailto:%20support@rudderstack.com).
+- All the other skipped views are not regenerated. You can either manually create those views or [contact us](mailto:%20support@rudderstack.com) to get them created.
 
 ## FAQs
 

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -201,7 +201,7 @@ Note that the <strong>querying cost will increase</strong> if you choose this me
 
 ### Switching from deduplication to partitioned tables
 
-You can easily switch from using the deduplication method to ingest your data in BigQuery to the partitioned tables by setting the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your open source RudderStack setup to `false`.
+You can easily switch from using the deduplication method to ingest your data in BigQuery to the partitioned tables by setting the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your RudderStack setup to `false`.
 
 RudderStack then does the following:
 

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -140,16 +140,16 @@ RudderStack uses the source name (written in snake case, for example, `source_na
 For more details on the tables and columns created by RudderStack, refer to the <a href="https://rudderstack.com/docs/data-warehouse-integrations/warehouse-schemas/">Warehouse Schema</a> guide.
 </div>
 
-RudderStack supports two modes by which data is ingested into BigQuery, driven by the configuration variable `warehouse.bigquery.isDedupEnabled`:
+RudderStack supports two modes by which data is ingested into BigQuery. If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source), you can manage this via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`:
 
-| Ingestion method | `isDedupEnabled`  |
+| Ingestion method | `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`  |
 | :-----------------| :-------------------|
-| Partition (default) | `False` |
-| Deduplication | `True` |
+| Partitioned tables (default) | `false` |
+| Deduplication | `true` |
 
 <div class="infoBlock">
 
-By default, deduplication is disabled by RudderStack.
+By default, RudderStack uses the partitioned tables method to ingest data into BigQuery. Deduplication is disabled.
 </div>
 
 ### Partitioned tables and views
@@ -182,22 +182,27 @@ Users can modify the view query to change the time window of the view. The defau
 
 ### Deduplication method
 
-In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables.
+In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables. To enable this method, set the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your open source RudderStack setup to `true`.
 
 <div class="warningBlock">
 
 Views will not be created for the tables if you choose the deduplication method.
 </div>
 
+<div class="warningBlock">
+
+Note that the <strong>querying cost will increase</strong> if you choose this method, as RudderStack removes the duplicates from the tables through sequential scans that happen on every warehouse upload. For example, if your warehouse upload frequency is set to  every 30 minutes, RudderStack performs a full scan on the <code class="inline-code">tracks</code> table every 30mins to upload any new events.
+</div>
+
 ### Switching from deduplication to partitioned tables
 
-You can easily switch from using the deduplication method to ingest your data in BigQuery to the partitioned tables by setting the config parameter `warehouse.bigquery.isDedupEnabled` to `false`.
+You can easily switch from using the deduplication method to ingest your data in BigQuery to the partitioned tables by setting the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your open source RudderStack setup to `false`.
 
 RudderStack then does the following:
 
-- Creates `users_view` while loading the `users` table.
+- Creates `users_view` while loading the `users` table, **if not already present**.
 - Creates the views for the new `track` events.
-- All the skipped views will be untouched, that is, left as is. You can either create those views or [contact us](mailto:%20support@rudderstack.com).
+- All the other skipped views are not regenerated. You can either manually create those views or [contact us](mailto:%20support@rudderstack.com).
 
 ## FAQs
 

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -150,7 +150,7 @@ RudderStack supports two modes by which data is ingested into BigQuery:
 By default, RudderStack uses the partitioned tables method to ingest data into BigQuery. Deduplication is disabled.
 </div>
 
-If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source), you can manage these modes via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`, as shown in the following table:
+If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source) or are hosting the RudderStack data plane, you can manage these modes via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`, as shown in the following table:
 
 | Ingestion method | `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`  |
 | :-----------------| :-------------------|

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -140,17 +140,22 @@ RudderStack uses the source name (written in snake case, for example, `source_na
 For more details on the tables and columns created by RudderStack, refer to the <a href="https://rudderstack.com/docs/data-warehouse-integrations/warehouse-schemas/">Warehouse Schema</a> guide.
 </div>
 
-RudderStack supports two modes by which data is ingested into BigQuery. If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source), you can manage this via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`:
+RudderStack supports two modes by which data is ingested into BigQuery:
 
-| Ingestion method | `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`  |
-| :-----------------| :-------------------|
-| Partitioned tables (default) | `false` |
-| Deduplication | `true` |
+- Partitioned tables (default method)
+- Deduplication
 
 <div class="infoBlock">
 
 By default, RudderStack uses the partitioned tables method to ingest data into BigQuery. Deduplication is disabled.
 </div>
+
+If you are using [open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source), you can manage these modes via the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`, as shown in the following table:
+
+| Ingestion method | `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED`  |
+| :-----------------| :-------------------|
+| Partitioned tables | `false` |
+| Deduplication | `true` |
 
 ### Partitioned tables and views
 

--- a/data-warehouse-integrations/google-bigquery.mdx
+++ b/data-warehouse-integrations/google-bigquery.mdx
@@ -187,7 +187,7 @@ Users can modify the view query to change the time window of the view. The defau
 
 ### Deduplication method
 
-In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables. To enable this method, set the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your RudderStack setup to `true`.
+In this method, RudderStack automatically discards any duplicate events while loading them into the BigQuery tables. To enable this method, set the environment variable `RSERVER_WAREHOUSE_BIGQUERY_IS_DEDUP_ENABLED` in your RudderStack data plane setup to `true`.
 
 <div class="warningBlock">
 


### PR DESCRIPTION
## Description of the change

> BigQuery dedup information added to the documentation.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [BigQuery documentation update - add information on deduplication method](https://www.notion.so/rudderstacks/BigQuery-documentation-update-add-information-on-deduplication-method-185c0f87725a47a5809c7dd0f1a5d255)