### PR TITLE
add Gatsby Link component to docs

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -20,7 +20,7 @@ Start building a better, warehouse-first CDP that delivers complete, unified dat
 
 ## Quick start
 
-- Familiarize yourself with all the RudderStack features. Refer to the [Glossary](https://rudderstack.com/docs/get-started/glossary/).
+- Familiarize yourself with all the RudderStack features. Refer to the <Link to="/get-started/glossary">Glossary</Link>.
 - Read more about RudderStack's [architecture](https://rudderstack.com/docs/get-started/rudderstack-architecture/).
 - Start using [RudderStack Cloud](https://app.rudderstack.com/signup?type=freetrial) or [set up open source RudderStack](https://rudderstack.com/docs/rudderstack-open-source/installing-and-setting-up-rudderstack/) on your preferred platform.
 - Learn how RudderStack tracking works and use `track`, `identify`, and other types of event calls in RudderStack. Refer to the [RudderStack API Spec](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/) for more information.

--- a/src/@rocketseat/gatsby-theme-docs/components/Docs/index.js
+++ b/src/@rocketseat/gatsby-theme-docs/components/Docs/index.js
@@ -8,6 +8,7 @@ import mediumZoom from "medium-zoom";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 import "@reach/tabs/styles.css";
 import Layout from "../Layout";
+import { Link } from "gatsby";
 import SEO from "../SEO";
 import PostNav from "./PostNav";
 import EditGithub from "@rocketseat/gatsby-theme-docs/src/components/Docs/EditGithub";
@@ -52,6 +53,7 @@ export default function Docs({ mdx, pageContext }) {
 
       return <pre {...preProps} />;
     },
+    Link,
     Tabs,
     TabList,
     Tab,


### PR DESCRIPTION
## Description of the change
Enables use of Gatsby Link component for internal linking. Includes one test link on the homepage- Docs team will migrate existing markdown-formatted links to use the much faster Link component

To test out the example link go to https://deploy-preview-585--rudderstack-docs-staging.netlify.app/#quick-start and compare clicking the Glossary link to other internal links

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
