### PR TITLE
Use gatsby link in OS vs. Cloud guide

### DIFF
--- a/docs/get-started/cloud-vs-open-source.mdx
+++ b/docs/get-started/cloud-vs-open-source.mdx
@@ -11,7 +11,7 @@ This guide compares the features in the two primary RudderStack offerings— [Ru
 
 <div class="infoBlock">
 
-RudderStack offers three plans as a part of <a href="https://app.rudderstack.com/signup?type=freetrial">RudderStack Cloud</a>: *Free*, *Pro*, and *Enterprise*. Refer to the  [Pricing](https://www.rudderstack.com/pricing) page for a detailed comparison and additional information on these plans.
+RudderStack offers three plans as a part of [RudderStack Cloud](https://app.rudderstack.com/signup?type=freetrial): *Free*, *Pro*, and *Enterprise*. Refer to the  [Pricing](https://www.rudderstack.com/pricing) page for a detailed comparison and additional information on these plans.
 </div>
 
 ## Feature comparison
@@ -26,7 +26,7 @@ RudderStack offers three plans as a part of <a href="https://app.rudderstack.com
 
 <div class="infoBlock">
 
-For more information on the data plane and control plane setup options in RudderStack Cloud and Open Source, refer to the <a href="#faq">FAQ</a> section below.
+For more information on the data plane and control plane setup options in RudderStack Cloud and Open Source, refer to the <Link to="/#faq">FAQ</Link> section below.
 </div>
 
 ### Event-related features
@@ -39,7 +39,7 @@ For more information on the data plane and control plane setup options in Rudder
 | RudderStack-hosted object storage | ✅ |  ❌  | You can use the RudderStack-hosted bucket to temporarily store your events before forwarding them to your warehouse destination. |
 | <Link to="/user-guides/administrators-guide/event-replay/">Event Replay</Link>| ✅ |  ❌  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. | 
 | Maintaining event ordering | ✅ |  ✅ | <ul><li>For Cloud, this is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature.</li><li>Event ordering is supported in an open source setup but **not guaranteed**.</li></ul> |
-| <Link to="/transformations">Transformations</Link> (cloud mode only) |  ✅ |  ✅ | <ul><li>For Open Source users, transformations are applicable only for the [RudderStack-hosted control plane](https://app.rudderstack.com/signup?type=opensource) and users can set up to **3 transformations**.</li><li><a href="https://app.rudderstack.com/signup?type=freetrial" target="_blank">RudderStack Cloud Free</a> users can set up to **3 transformations**.</li><li>Pro and Enterprise users can create unlimited transformations.</li></ul> |
+| <Link to="/transformations">Transformations</Link> (cloud mode only) |  ✅ |  ✅ | <ul><li>For Open Source users, transformations are applicable only for the [RudderStack-hosted control plane](https://app.rudderstack.com/signup?type=opensource) and users can set up to **3 transformations**.</li><li>[RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial) users can set up to **3 transformations**.</li><li>Pro and Enterprise users can create unlimited transformations.</li></ul> |
 
 ### ETL and Reverse ETL
 

--- a/docs/get-started/cloud-vs-open-source.mdx
+++ b/docs/get-started/cloud-vs-open-source.mdx
@@ -18,11 +18,11 @@ RudderStack offers three plans as a part of <a href="https://app.rudderstack.com
 
 ### Setup and customizability
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments | 
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes | 
 | :--------| :-------------------| :--------------------------| :-----|
-| <Link to="/rudderstack-open-source/installing-and-setting-up-rudderstack">Data plane setup</Link> in your own environment |  ✕ |  ✓ | Cloud uses the RudderStack-hosted <Link to="/get-started/rudderstack-architecture">data plane</Link>. | 
-| [Control plane setup](https://www.rudderstack.com/docs/rudderstack-open-source/control-plane-lite/) in your own environment  |  ✕ |  ✓ | Cloud uses the RudderStack-hosted [web app](https://app.rudderstack.com/) to manage your connections. |
-| Customize the data plane [config parameters](https://github.com/rudderlabs/rudder-server/blob/master/config/config.yaml) | ✕ |  ✓ |  - |
+| <Link to="/rudderstack-open-source/installing-and-setting-up-rudderstack">Data plane setup</Link> in your own environment |  ❌ |  ✅ | Cloud uses the RudderStack-hosted <Link to="/get-started/rudderstack-architecture">data plane</Link>. | 
+| <Link to="/rudderstack-open-source/control-plane-lite">Control plane setup</Link> in your own environment  |  ❌ |  ✅ | Cloud uses the RudderStack-hosted [web app](https://app.rudderstack.com/) to manage your connections. |
+| Customize the data plane [config parameters](https://github.com/rudderlabs/rudder-server/blob/master/config/config.yaml) | ❌ |  ✅ |  - |
 
 <div class="infoBlock">
 
@@ -31,77 +31,77 @@ For more information on the data plane and control plane setup options in Rudder
 
 ### Event-related features
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments |
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes |
 | :--------| :-------------------| :--------------------------| :-----| 
-| Event-related metrics | ✓ |  ✓ | Get information on the number of events ingested during a specified timeframe. | 
-| [Event backup in your own bucket](https://www.rudderstack.com/docs/user-guides/administrators-guide/bucket-configuration-settings/) |  ✓ |  ✓ | RudderStack can manage it for you as a part of the [Enterprise plan](https://www.rudderstack.com/enterprise-quote/). | 
-| [Live events](https://www.rudderstack.com/docs/rudderstack-cloud/live-events/) |  ✓ | ✕ | This feature is applicable only for [cloud mode](https://www.rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/#cloud-mode) destinations. | 
-| RudderStack-hosted object storage | ✓ |  ✕ | You can use the RudderStack-hosted bucket to temporarily store your events before forwarding them to your warehouse destination. |
-| [Event Replay](https://www.rudderstack.com/docs/user-guides/administrators-guide/event-replay/) | ✓ |  ✕ | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. | 
-| Maintaining event ordering | ✓ |  ✓ | <ul><li>For Cloud, this is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature.</li><li>Event ordering is supported in an open source setup but **not guaranteed**.</li></ul> |
-| [Transformations](https://www.rudderstack.com/docs/transformations/) |  ✓ |  ✓ | <ul><li>In case of Open Source, this feature is only applicable for the [RudderStack-hosted control plane](https://app.rudderstack.com/signup?type=opensource) and users can set upto <strong>3 transformations</strong>.</li><li>In case of <a href="https://app.rudderstack.com/signup?type=freetrial" target="_blank">RudderStack Cloud Free</a>, users can set upto <strong>3 transformations</strong>.</li><li>Pro and Enterprise users can set up unlimited transformations.</li><li>It can be used only for [cloud mode](https://www.rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/#cloud-mode) destinations.</li></ul> |
+| Event-related metrics | ✅ |  ✅ | Get information on the number of events ingested during a specified timeframe. | 
+| <Link to="/user-guides/administrators-guide/bucket-configuration-settings">Event backup in your own bucket</Link> |  ✅ |  ✅ | RudderStack can manage it for you as a part of the [Enterprise plan](https://www.rudderstack.com/enterprise-quote/). | 
+| <Link to="/rudderstack-cloud/live-events">Live events</Link> |  ✅ | ❌  | This feature is applicable only for <Link to="/rudderstack-cloud/rudderstack-connection-modes/#cloud-mode">cloud mode</Link> destinations. | 
+| RudderStack-hosted object storage | ✅ |  ❌  | You can use the RudderStack-hosted bucket to temporarily store your events before forwarding them to your warehouse destination. |
+| <Link to="/user-guides/administrators-guide/event-replay/">Event Replay</Link>| ✅ |  ❌  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. | 
+| Maintaining event ordering | ✅ |  ✅ | <ul><li>For Cloud, this is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature.</li><li>Event ordering is supported in an open source setup but **not guaranteed**.</li></ul> |
+| <Link to="/transformations">Transformations</Link> (cloud mode only) |  ✅ |  ✅ | <ul><li>For Open Source users, transformations are applicable only for the [RudderStack-hosted control plane](https://app.rudderstack.com/signup?type=opensource) and users can set up to **3 transformations**.</li><li><a href="https://app.rudderstack.com/signup?type=freetrial" target="_blank">RudderStack Cloud Free</a> users can set up to **3 transformations**.</li><li>Pro and Enterprise users can create unlimited transformations.</li></ul> |
 
 ### ETL and Reverse ETL
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments |
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes |
 | :--------| :-------------------| :--------------------------| :-----| 
-| [Cloud Extract (ETL)](https://www.rudderstack.com/docs/cloud-extract-sources/) | ✓ |  ✕  | [RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial) users can set up only 1 Cloud Extract source. Pro and Enterprise users can set up unlimited sources.  | 
-| [Reverse ETL](https://www.rudderstack.com/docs/reverse-etl/) | ✓ |  ✕ |  [RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial) users can set up only 1 Reverse ETL source. Pro and Enterprise users can set up unlimited sources.  | 
-| Data syncs scheduling | ✓ |  ✕  |  - |
-| [Models](https://www.rudderstack.com/docs/reverse-etl/features/models/) | ✓ |  ✕  | Models let you define and run custom SQL queries on your warehouse and send the resulting data to specific destinations. |
+| <Link to="/cloud-extract-sources">Cloud Extract (ETL)</Link> | ✅ |  ❌   | [RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial) users can set up 1 Cloud Extract source. Pro and Enterprise users can set up unlimited sources.  | 
+| <Link to="/reverse-etl">Reverse ETL</Link> | ✅ |  ❌  |  [RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial) users can set up 1 Reverse ETL source. Pro and Enterprise users can set up unlimited sources.  | 
+| Data syncs scheduling | ✅ |  ❌   |  - |
+| <Link to="/reverse-etl/features/models">Models</Link> | ✅ |  ❌   | Models let you define and run custom SQL queries on your warehouse and send the resulting data to specific destinations. |
 
 ### Data governance
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments |
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes |
 | :--------| :-------------------| :--------------------------| :-----| 
-| [Data governance](https://www.rudderstack.com/docs/data-governance/) | ✓ |  ✕ | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
-| [Tracking plans](https://www.rudderstack.com/docs/data-governance/tracking-plans/) | ✓ |  ✕ | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
-| [Data regulation and suppression](https://www.rudderstack.com/docs/rudderstack-api/data-regulation-api/) | ✓ |  ✕ | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
+| <Link to="/data-governance">Data governance</Link> | ✅ |  ❌  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
+| <Link to="/data-governance/tracking-plans">Tracking plans</Link> | ✅ |  ❌  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
+| <Link to="/rudderstack-api/data-regulation-api">Data regulation and suppression</Link> | ✅ |  ❌  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
 
 ### Deployment and security
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments |
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes |
 | :--------| :-------------------| :--------------------------| :-----|
-| Multi-node scaling | ✓ |  ✕  | Available for Pro and Enterprise users. |
-| Single sign-on(SSO) | ✓ |  ✕  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
-| VPC deployment | ✓ |  ✕  | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
+| Multi-node scaling | ✅ |  ❌   | Available for Pro and Enterprise users. |
+| Single sign-on(SSO) | ✅ |  ❌   | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
+| VPC deployment | ✅ |  ❌   | This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
 
 ### Monitoring and observability
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments |
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes |
 | :--------| :-------------------| :--------------------------| :-----| 
-| Grafana dashboards for monitoring | ✓ |  ✕  |  Available for Pro and Enterprise users. |
-| Alerting and error notifications | ✓ |  ✕  |  This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature.  |
+| Grafana dashboards for monitoring | ✅ |  ❌   |  Available for Pro and Enterprise users. |
+| Alerting and error notifications | ✅ |  ❌   |  This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature.  |
 
 ### Auditing and user management
 
-| Feature |  RudderStack Cloud | RudderStack Open Source | Comments |
+| Feature |  RudderStack Cloud | RudderStack Open Source | Notes |
 | :--------| :-------------------| :--------------------------| :-----| 
-| Ability to add other team members in the workspace | ✓ |  ✕  |  You can invite upto 3 members in your workspace in [RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial), upto 10 members in Pro, and unlimited members in the Enterprise plan. | 
-| Audit logs | ✓ |  ✕  |  This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
+| Ability to add other team members in the workspace | ✅ |  ❌   |  You can invite up to 3 members to your workspace in [RudderStack Cloud Free](https://app.rudderstack.com/signup?type=freetrial), up to 10 members in Pro, and unlimited members in the Enterprise plan. | 
+| Audit logs | ✅ |  ❌   |  This is an [Enterprise-only](https://www.rudderstack.com/enterprise-quote/) feature. |
 
 ## FAQ
 
 ### What is the data plane and control plane in RudderStack? How do I set them up?
 
-The data plane is RudderStack's core engine responsible for receiving the event data, transforming it into the required destination format, before relaying those events to the destination.
+The data plane is RudderStack's core engine responsible for receiving event data and transforming it into the required destination format before relaying events to the destination.
 
-The control plane manages the configuration of your sources and destinations in RudderStack.
+The control plane is the front-end web application where you manage the configuration of your sources and destinations in RudderStack.
 
 <div class="infoBlock">
 
-For more information on the data plane and control plane in RudderStack, refer to the <a href="https://www.rudderstack.com/docs/get-started/rudderstack-architecture/">Architecture</a> guide.
+For more information on the data plane and control plane in RudderStack, refer to the <Link to="/get-started/rudderstack-architecture">Architecture</Link> guide.
 </div>
 
-In case of [RudderStack Cloud](https://rudderstack.com/docs/rudderstack-cloud/), RudderStack self-hosts the data plane and the control plane so you don't have to worry about their setup.
+In <Link to="/rudderstack-cloud">RudderStack Cloud</Link>, we host the data plane and the control plane so you don't have to worry about their setup.
 
-For [RudderStack Open Source](https://rudderstack.com/docs/rudderstack-open-source/), you get the following data plane and control plane setup options:
-- You need to [set up the data plane](https://www.rudderstack.com/docs/rudderstack-open-source/installing-and-setting-up-rudderstack/) in your own environment. **RudderStack will not host it for you**.
-- For the control plane, you can either use the [RudderStack-hosted control plane](https://app.rudderstack.com/signup?type=opensource) or [set up your own control plane](https://www.rudderstack.com/docs/rudderstack-open-source/control-plane-lite/).
+For <Link to="/rudderstack-open-source">RudderStack Open Source</Link> you have the following data plane and control plane setup options:
+- <Link to="/rudderstack-open-source/installing-and-setting-up-rudderstack">Set up the data plane</Link> in your own environment. <strong>RudderStack will not host it for you</strong>.
+- For the control plane, you can either use the [RudderStack-hosted control plane](https://app.rudderstack.com/signup?type=opensource) or <Link to="/rudderstack-open-source/control-plane-lite">set up your own control plane</Link>.
 
 <div class="warningBlock">
 
-Features like <a href="https://www.rudderstack.com/docs/transformations/">Transformations</a> and <a href="https://www.rudderstack.com/docs/rudderstack-cloud/live-events/">Live Events</a> are not available if you self-host the control plane.
+Features like <Link to="/transformations/">Transformations</Link> and <Link to="/rudderstack-cloud/live-events/">Live Events</Link> are not available if you self-host the control plane.
 </div>
 
 ## Contact us

--- a/docs/get-started/cloud-vs-open-source.mdx
+++ b/docs/get-started/cloud-vs-open-source.mdx
@@ -7,11 +7,11 @@ description: >-
 
 # RudderStack Cloud vs. RudderStack Open Source
 
-This guide compares the features present in the two primary [RudderStack](https://rudderstack.com/) offerings - [RudderStack Cloud](https://app.rudderstack.com/signup?type=freetrial) and [RudderStack Open Source](https://app.rudderstack.com/signup?type=opensource). It will help you in choosing the best option suited to your requirements.
+This guide compares the features in the two primary RudderStack offerings— [RudderStack Cloud](https://app.rudderstack.com/signup?type=freetrial) and [RudderStack Open Source](https://app.rudderstack.com/signup?type=opensource). It will help you choose the option that best suits your requirements.
 
 <div class="infoBlock">
 
-RudderStack also offers three plans as a part of <a href="https://app.rudderstack.com/signup?type=freetrial">RudderStack Cloud</a> : Free, Pro, and Enterprise. Refer to the  <a href="https://www.rudderstack.com/pricing/">Pricing</a> page for detailed comparison and additional information on these plans.
+RudderStack offers three plans as a part of <a href="https://app.rudderstack.com/signup?type=freetrial">RudderStack Cloud</a>: *Free*, *Pro*, and *Enterprise*. Refer to the  [Pricing](https://www.rudderstack.com/pricing) page for a detailed comparison and additional information on these plans.
 </div>
 
 ## Feature comparison
@@ -20,7 +20,7 @@ RudderStack also offers three plans as a part of <a href="https://app.rudderstac
 
 | Feature |  RudderStack Cloud | RudderStack Open Source | Comments | 
 | :--------| :-------------------| :--------------------------| :-----|
-| [Data plane setup](https://www.rudderstack.com/docs/rudderstack-open-source/installing-and-setting-up-rudderstack/) in your own environment |  ✕ |  ✓ | Cloud uses the RudderStack-hosted [data plane](https://www.rudderstack.com/docs/get-started/rudderstack-architecture/). | 
+| <Link to="/rudderstack-open-source/installing-and-setting-up-rudderstack">Data plane setup</Link> in your own environment |  ✕ |  ✓ | Cloud uses the RudderStack-hosted <Link to="/get-started/rudderstack-architecture">data plane</Link>. | 
 | [Control plane setup](https://www.rudderstack.com/docs/rudderstack-open-source/control-plane-lite/) in your own environment  |  ✕ |  ✓ | Cloud uses the RudderStack-hosted [web app](https://app.rudderstack.com/) to manage your connections. |
 | Customize the data plane [config parameters](https://github.com/rudderlabs/rudder-server/blob/master/config/config.yaml) | ✕ |  ✓ |  - |
 

--- a/docs/get-started/glossary.mdx
+++ b/docs/get-started/glossary.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Glossary"
-description: General glossary of the RudderStack-related features to help you get familiarized with the product.
+description: Get familiarized with the RudderStack-specific features and terminology.
 ---
 
 # Glossary
@@ -11,42 +11,42 @@ This guide lists the definitions of the RudderStack-related terms that you are l
 
 Audit Logs is RudderStack's [enterprise]( https://rudderstack.com/pricing/) feature that gives you a detailed log of the user activities happening within your RudderStack workspace. These activities include the various user operations related to sources, destinations, transformations, and more.
 
-For more information on the audit logs feature, refer to the [Audit Logs](https://rudderstack.com/docs/rudderstack-cloud/audit-logs/) guide.
+For more information on the audit logs feature, refer to the <Link to="/rudderstack-cloud/audit-logs">Audit Logs</Link> guide.
 
 ## Cloud Extract
 
-[Cloud Extract](https://rudderstack.com/docs/cloud-extract-sources/) is RudderStack's ELT feature that lets you collect your raw events and data from various third-party cloud platforms such as Google Analytics, Marketo, Facebook Ads, Stripe, etc. and send it to your data warehouse with a user-specified frequency.
+Cloud Extract is RudderStack's ELT feature that lets you collect your raw events and data from various third-party cloud platforms and send it to your data warehouse.
 
-For more information on the various Cloud Extract sources and how to set them up in RudderStack, refer to the [Cloud Extract](https://rudderstack.com/docs/cloud-extract-sources/) guide.
+For more information on the various Cloud Extract sources and how to set them up in RudderStack, refer to the <Link to="/cloud-extract-sources">Cloud Extract</Link> documentation.
 
 ## Connection (Pipeline)
 
 A connection is a one-to-one directional flow of events between a RudderStack source and a destination.
 
-For more information on sources and destinations in RudderStack, refer to the [RudderStack Cloud](https://rudderstack.com/docs/rudderstack-cloud/) section.
+For more information on sources and destinations in RudderStack, refer to the <Link to="/rudderstack-cloud">RudderStack Cloud</Link> section.
 
 You can set up different types of connections in RudderStack to send your events, based on the type of source:
 
 * **Event Stream**:  One source to many destinations
 * **Cloud Extract**: Multiple sources to one warehouse destination
-* **Reverse ETL**: One warehouse source to one downstream destination (mainly due to the mappings required when setting up the connection).
+* **Reverse ETL**: One warehouse source to one downstream destination (this is mainly due to the mappings required when setting up the connection)
 
 ## Connection modes (cloud mode and device mode)
 
 You can send the event data from your sources to your desired destinations via RudderStack in two ways:
 
-* **Cloud mode**: In this mode, the RudderStack SDKs track and send the event data directly to the RudderStack server for processing. RudderStack processes this data and routes it to the desired destination. This mode is useful when you want to leverage the [Transformations](#transformations) feature to transform your events before sending them over to the destinations.
-* **Device mode**: In this mode, you can send the source events to the destinations using the native client-specific libraries on your website/mobile app. These libraries allow RudderStack to use the data you collect on your device to call the destination APIs without sending it to the RudderStack server first. This mode is useful when you want to send the events to a destination as-is, without any transformation.
+* **Cloud mode**: In this mode, the RudderStack SDKs track and send the event data directly to the RudderStack server for processing. RudderStack processes this data and routes it to the desired destination. This mode is useful when you want to leverage the <Link to="/transformations">Transformations</Link> feature to transform your events before sending them over to the destinations.
+* **Device mode**: In this mode, you can send the source events to the destinations using the native client-specific libraries on your website/mobile app. These libraries allow RudderStack to use the data you collect on your device to call the destination APIs without sending it to the RudderStack server first. This mode is useful when you want to send the events to a destination directly, without any transformation.
 
 These two modes are commonly referred to as RudderStack connection modes.
 
-For more information, refer to the [RudderStack connection modes](https://rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/) guide.
+For more information, refer to the <Link to="/rudderstack-cloud/rudderstack-connection-modes">Connection Modes</Link> guide.
 
 ## Control plane
 
 The control plane manages the configuration of your sources and destinations. The interface for the control plane is the [RudderStack web app](https://app.rudderstack.com/).
 
-For more information on the control plane, refer to the [Architecture](https://rudderstack.com/docs/get-started/rudderstack-architecture/) guide.
+For more information on the control plane, refer to the <Link to="/get-started/rudderstack-architecture">Architecture</Link> guide.
 
 ## Control Plane Lite
 
@@ -54,15 +54,17 @@ RudderStack's control plane offers an intuitive UI to configure your event data 
 
 If you want to self-host these configurations, you can use the open source Control Plane Lite utility to set up your control plane. You can then manage the source and destination configurations locally by exporting to or importing them from a JSON file.
 
-For information on Control Plane Lite and how to use it, refer to the [Control Plane Lite](https://rudderstack.com/docs/rudderstack-open-source/control-plane-lite/) guide.
+For information on Control Plane Lite and how to use it, refer to the <Link to="/rudderstack-open-source/control-plane-lite">Control Plane Lite</Link> guide.
 
 ## Customer Data Platform
 
-A Customer Data Platform (CDP) is a software/collection of tools that unifies and persists all the customer-specific records across multiple data sources in a centralized location accessible to other tools/platforms. A CDP lets you build a comprehensive customer profile and use the insights for a variety of use-cases.
+A Customer Data Platform (CDP) is a software/collection of tools that unifies and persists all the customer records across multiple data sources in a centralized location accessible to other tools in your tech stack. 
+
+A CDP lets you build a comprehensive customer profile and use the insights for a variety of use-cases.
 
 ## Data governance
 
-RudderStack's [Data Governance](https://rudderstack.com/docs/data-governance/) feature gives you the ability to access all your events and their metadata programmatically and identify any inconsistencies in them. This includes vital information related to the event schema, event payload versions, data types, and more.
+RudderStack's <Link to="/data-governance">Data Governance</Link> feature gives you the ability to access all your events and their metadata programmatically and identify any inconsistencies in them. This includes vital information related to the event schema, event payload versions, data types, and more.
 
 ## Data plane
 
@@ -72,26 +74,44 @@ The data plane is RudderStack's core engine responsible for:
 * Transforming the events into the required destination format
 * Relaying the events to the destination
 
-For more information on the data plane, refer to the [Architecture](https://rudderstack.com/docs/get-started/rudderstack-architecture/) guide.
+For more information on the data plane, refer to the <Link to="/get-started/rudderstack-architecture">Architecture</Link> guide.
 
-The data plane is intentionally separated from the control plane to give you complete ownership of your data. Depending on how RudderStack is deployed, you can set up your control plane and data plane via one of the following approaches:
+The data plane is intentionally separated from the control plane to give you complete control and ownership of your data. Depending on how RudderStack is deployed, you can set up your control plane and data plane with one of the following approaches:
 
-* [RudderStack Cloud](https://rudderstack.com/docs/rudderstack-cloud/): RudderStack hosts both control plane and data plane
-* [RudderStack Open Source](https://rudderstack.com/docs/rudderstack-open-source/): RudderStack hosts the control plane and the user hosts the data plane. Alternatively, the user hosts both the control plane and the data plane.
+* <Link to="/rudderstack-cloud">RudderStack Cloud</Link>: RudderStack hosts both control plane and data plane
+* <Link to="/rudderstack-open-source">RudderStack Open Source</Link>: RudderStack hosts the control plane and the user hosts the data plane. Alternatively, the user hosts both the control plane and the data plane.
+
+## Data plane URL 
+
+For routing and processing the events to the RudderStack backend, a data plane URL is required.
+
+<div class="infoBlock">
+
+Refer to the <Link to="/get-started/rudderstack-architecture">Architecture</Link> guide for more information on the RudderStack data plane.
+</div>
+
+- If you're using [RudderStack Cloud Free](https://app.rudderstack.com/), the data plane URL is present in your dashboard itself.
+- If you're using [RudderStack Pro](https://rudderstack.com/pricing/) or [Enterprise](https://rudderstack.com/pricing/), [contact us](mailto:%20support@rudderstack.com) for the data plane URL with the email ID you used to sign up for RudderStack.
+- If you're using <Link to="/rudderstack-open-source">RudderStack Open Source</Link>, you are required to set up your own data plane by <Link to="/rudderstack-open-source/installing-and-setting-up-rudderstack/">installing and setting up RudderStack</Link> in your preferred environment.
+
+<div class="infoBlock">
+
+An open source data plane URL typically looks like <code class="inline-code">http:localhost:8080</code> where <code class="inline-code">8080</code> is the port where your RudderStack data plane is hosted.
+</div>
 
 ## Data Regulation API
 
-[Data Regulation](https://www.rudderstack.com/docs/rudderstack-api/data-regulation-api/) is RudderStack's enterprise feature that lets you programmatically suppress user data identified by a user ID. With this feature, you can block all the user data for all the sources and destinations in RudderStack.
+Data Regulation API is RudderStack's enterprise feature that lets you programmatically suppress user data identified by a user ID. With this feature, you can block all the user data for all the sources and destinations in RudderStack.
 
-Refer to the [Data Regulation API](https://www.rudderstack.com/docs/rudderstack-api/data-regulation-api/) guide for more information.
+Refer to the <Link to="/rudderstack-api/data-regulation-api">Data Regulation API</Link> guide for more information.
 
 ## Destination
 
 A destination is a tool or application where you want to send the data via RudderStack.
 
-RudderStack currently supports over 150 destinations. These include [data warehouses](https://rudderstack.com/docs/data-warehouse-integrations/), [analytics](https://rudderstack.com/docs/destinations/analytics/) platforms, [CRMs](https://rudderstack.com/docs/destinations/crm/), [marketing](https://rudderstack.com/docs/destinations/marketing/) platforms, and more.
+RudderStack currently supports over 150 destinations. These include <Link to="/data-warehouse-integrations">data warehouses</Link>, <Link to="/destinations/analytics">analytics platforms</Link>, <Link to="/destinations/crm">CRM tools</Link>, <Link to="/destinations/marketing">marketing platforms</Link>, and more.
 
-Refer to the [Destinations](https://rudderstack.com/docs/destinations/) guide for the complete list of the supported destinations.
+Refer to the <Link to="/destinations">Destinations</Link> guide for the complete list of the supported destinations.
 
 ## ELT (Extract, Load, Transform)
 
@@ -101,7 +121,7 @@ The ELT \(Extract, Load, Transform\) process can be defined as:
 * Load: Replicating the data from the source into the target system, typically a data warehouse or a data lake.
 * Transformation: Transforming the data in the desired format according to the business requirement/use-case.
 
-Refer to the [RudderStack blog](https://rudderstack.com/blog/rudderstack-cloud-extract-makes-cloud-to-warehouse-pipelines-easy) to read more about ELT and how RudderStack facilitates it via the [Cloud Extract](https://rudderstack.com/docs/cloud-extract-sources/) feature.
+Refer to the [RudderStack blog](https://rudderstack.com/blog/rudderstack-cloud-extract-makes-cloud-to-warehouse-pipelines-easy) to read more about ELT and how RudderStack facilitates it via the <Link to="/cloud-extract-sources">Cloud Extract</Link> feature.
 
 ## Event
 
@@ -109,90 +129,93 @@ Events are the fundamental components of clickstream data. They correspond to th
 
 Tracking events in real-time helps businesses to better understand the users and their product journey. This, in turn, allows businesses to deliver better recommendations, send relevant push notifications, and enhance user experience.
 
-Check out the [RudderStack blog post](https://rudderstack.com/blog/clickstream-analytics-gamechanger-for-ecommerce) to read more about clickstream analytics.
+Refer to the [RudderStack blog post](https://rudderstack.com/blog/clickstream-analytics-gamechanger-for-ecommerce) to read more about clickstream analytics.
 
 ## Event spec
 
-The RudderStack event spec helps you plan your event data and provides various options for tracking your events across all the RudderStack SDKs and APIs. As RudderStack has a unified event semantic for different destination platforms, you can easily translate your event data to different downstream tools by following this spec.
+The RudderStack event spec helps you plan your event data and provides various options for tracking your events across all the RudderStack SDKs and APIs. RudderStack has a unified event semantic for different destination platforms, so you can easily translate your event data to different downstream tools by following this spec.
 
-For more information on the RudderStack event spec, refer to the [Event Spec](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/) guide.
+For more information on the RudderStack event spec, refer to the <Link to="/rudderstack-api/api-specification/rudderstack-spec">Event Spec</Link> guide.
 
-## Event Stream
+## Event Streams
 
-RudderStack's [Event Stream](https://rudderstack.com/docs/stream-sources/) feature lets you collect your event data from all of your web and mobile apps and route it to a wide array of customer tools and data warehouses via RudderStack.
+RudderStack's Event Streams feature lets you collect your event data from all of your web and mobile apps and route it to a wide array of customer tools and data warehouses via RudderStack.
 
-For more information on the various Event Stream sources supported by RudderStack, refer to the [Event Stream](https://rudderstack.com/docs/stream-sources/) guide.
+For more information on the various Event Streams sources supported by RudderStack, refer to the <Link to="/stream-sources">Event Streams</Link> guide.
 
 ## Live Events
 
-RudderStack's [Live Events](https://rudderstack.com/docs/rudderstack-cloud/live-events/) feature offers a debugger that shows the live events collected from your sources and sent to the connected destinations in real-time. With this feature, you can easily debug any errors in the failing events at a destination level and reduce your troubleshooting time and efforts.
+RudderStack's <Link to="/rudderstack-cloud/live-events">Live Events</Link> feature is a debugger that shows the live events collected from your sources and sent to the connected destinations in real-time. With this feature, you can easily debug any errors in the failing events at a destination level and reduce your troubleshooting time and efforts.
 
 Broadly speaking, this feature can be further classified into two major categories:
 
-* [Source Live Events](https://rudderstack.com/docs/rudderstack-cloud/live-events#source-live-events): This feature gives you real-time visibility into the source events collected by RudderStack. This way, you can confirm if your source is configured correctly and is collecting & sending data as expected. 
-* [Destination Live Events](https://rudderstack.com/docs/rudderstack-cloud/live-events#destination-live-events): When routing events to a destination, sometimes events don't show up in your destination. This feature gives you real-time visibility into the destination's responses and helps you troubleshoot the problem.
+* <Link to="/rudderstack-cloud/live-events#source-live-events">Source Live Events</Link>: This feature gives you real-time visibility into the source events collected by RudderStack. This way, you can confirm if your source is configured correctly and is collecting & sending data as expected. 
+* <Link to="/rudderstack-cloud/live-events#destination-live-events">Destination Live Events</Link>: When routing events to a destination, sometimes events don't show up in your destination. This feature gives you real-time visibility into the destination's responses and helps you troubleshoot the problem.
 
 ## Reverse ETL
 
 Reverse ETL is the process of routing the data residing in your data warehouse to various downstream tools within your customer data stack. This includes various SaaS marketing, analytics, sales, and customer support tools.
 
-Check out the [RudderStack blog](https://rudderstack.com/blog/reverse-etl-is-just-another-data-pipeline) to read more about the Reverse ETL. For more information on the supported Reverse ETL sources and setting them up in RudderStack, refer to the [Reverse ETL documentation](https://rudderstack.com/docs/reverse-etl/).
+Refer to the [RudderStack blog](https://rudderstack.com/blog/reverse-etl-is-just-another-data-pipeline) to read more about Reverse ETL. For more information on the supported Reverse ETL sources and setting them up in RudderStack, refer to the <Link to="/reverse-etl">Reverse ETL</Link> documentation.
 
 ## SDK
 
-RudderStack offers client-side SDK support for your web, mobile, and server-side sources and lets you track your event data seamlessly.
+RudderStack offers SDK support for your web, mobile, and server-side sources and lets you track your event data seamlessly.
 
-Refer to the [SDK documentation](https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/) for more details.
+ For the SDK-specific documentation, refer to the <Link to="/stream-sources/rudderstack-sdk-integration-guides">SDK Integration Guides</Link>.
 
 ## Source
 
 A source is a platform or an application \(web, mobile, server-side, or a third-party cloud app\) from where RudderStack tracks and collects your event data.
 
-For more information on RudderStack sources, refer to the [Sources](https://rudderstack.com/docs/rudderstack-cloud/sources/) guide.
+For more information on RudderStack sources, refer to the <Link to="/rudderstack-cloud/sources/">Sources</Link> guide.
 
 ## Visual Data Mapper
 
-The Visual Data Mapper (VDM) is a Reverse ETL feature. It offers an intuitive UI to map your data warehouse columns to specific destination fields without any second-guessing.
+The Visual Data Mapper (VDM) is RudderStack's Reverse ETL feature. It offers an intuitive UI to map your data warehouse columns to specific destination fields without any second-guessing.
 
-For more information on RudderStack sources, refer to the [Visual Data Mapper](https://rudderstack.com/docs/reverse-etl/features/visual-data-mapper/) guide.
+For more information on this feature, refer to the <Link to="/reverse-etl/features/visual-data-mapper/">Visual Data Mapper</Link> guide.
 
-## Teammates
+## Teammates (User Management)
 
-RudderStack's Teammates (user management) feature enables you to add and manage other users in your current RudderStack workspace. It facilitates easier collaboration between you and other team members of your organization while using RudderStack.
+RudderStack's Teammates feature lets you add and manage other users in your RudderStack workspace. It facilitates easier collaboration between you and other team members of your organization while using RudderStack.
 
-For more information on this feature, refer to the [Teammates](https://rudderstack.com/docs/rudderstack-cloud/teammates/) guide.
+For more information on this feature, refer to the <Link to="/rudderstack-cloud/teammates/">Teammates</Link> guide.
 
 ## Transformations
 
-RudderStack's [Transformations](https://www.rudderstack.com/docs/transformations/) feature lets you leverage your custom JavaScript functions that you can use to implement a variety of use-cases like: 
+RudderStack's <Link to="/transformations">Transformations</Link> feature lets you leverage your custom JavaScript functions that you can use to implement a variety of use-cases like: 
 
   * Filtering or sampling events
   * Implementing a static logic to enrich your events
   * Removing any sensitive PII information from your customer events, and a lot more.
 
-For more details on this feature and how to use it, refer to the [Transformations](https://rudderstack.com/docs/transformations/) guide.
+For more details on this feature and how to use it, refer to the <Link to="/transformations">Transformations</Link> guide.
 
 ## Warehouse destination
 
 RudderStack supports sending events to all the leading data warehouses like Redshift, Azure Synapse, BigQuery, Snowflake, PostgreSQL, ClickHouse, and SQL Server. These are called the warehouse destinations.
 
-For more information on how to set up these warehouse destinations, refer to the [Warehouse Destinations](https://rudderstack.com/docs/data-warehouse-integrations) guides.
+For more information on how to set up these warehouse destinations, refer to the <Link to="/data-warehouse-integrations">Warehouse Destinations</Link> guide.
 
 ## Warehouse schema
 
-When sending your events to a data warehouse via RudderStack, you need not define a schema for the event data before sending it from your source. Instead, RudderStack automatically does that for you by following a predefined warehouse schema. This schema defines the different tables and columns created based on different events.
+When sending your events to a data warehouse via RudderStack, you don't need to define a schema for your events before sending them from your source. RudderStack automatically does that for you by following a predefined warehouse schema. This schema defines the different tables and columns created based on different types of events.
 
-Refer to the [Warehouse Schema](https://rudderstack.com/docs/data-warehouse-integrations/warehouse-schemas/) guide for more details.
+Refer to the <Link to="/data-warehouse-integrations/warehouse-schemas">Warehouse Schema</Link> guide for more details.
 
 ## Token
 
-The token (also referred to as the workspace token) is a unique identifier of your RudderStack workspace. You can find it by logging in to the RudderStack web app.
+The token (also referred to as the workspace token) is a unique identifier of your RudderStack workspace. You can find it by logging in to your [RudderStack dashboard](https://app.rudderstack.com/).
 
 ## Write key
 
 The write key (also referred to as the source write key) is a unique identifier for your source. It is used while sending events from a source to your specified destination via RudderStack.
 
 <img src="../assets/rudderstack-open-source/write-key-vs-workspace-token.png" alt="Workspace Token vs Source Write Key" />
+<br /><br />
+
+For more information on finding the write key for your source, refer to the <Link to="/rudderstack-cloud/sources#faq">Sources</Link> guide.
 
 ## Contact us
 

--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -2,12 +2,12 @@
 #slug: "/docs/get-started"
 title: "Get Started"
 description: >-
-  Get started with RudderStack - the warehouse-first customer data platform for developers.
+  Get started with RudderStack - set up a connection and see your events flow in no time.
 ---
 
 # Get Started
 
-The easiest way to get started with RudderStack is to set up a source, connect it to a destination, and see your event data flow in no time.
+The easiest way to get started with RudderStack is to set up a source-destination connection in the RudderStack dashboard.
 
 ## Quick start
 
@@ -22,14 +22,14 @@ Follow these steps to set up a connection in RudderStack:
 
 <div class="infoBlock">
 
-For more information on sources in RudderStack, check out the <a href="https://rudderstack.com/docs/rudderstack-cloud/sources/">Sources</a> guide.
+For more information on sources in RudderStack, refer to the <Link to="/rudderstack-cloud/sources">Sources</Link> guide.
 </div>
 
 4. Choose the data source from the list of available sources. RudderStack supports the following three types of sources:
 
-    - [Event Streams](https://rudderstack.com/docs/stream-sources/): Collect your event data from all the web, mobile, and server-side apps, then route it to a wide array of customer tools and data warehouses.
-    - [Cloud Extract](https://rudderstack.com/docs/cloud-extract-sources/): Build ELT pipelines from cloud apps to your data warehouse.
-    - [Reverse ETL](https://rudderstack.com/docs/reverse-etl/): Leverage your warehouse as a data source for your entire customer data stack.
+    - <Link to="/stream-sources">Event Streams</Link>: Collect your event data from all the web, mobile, and server-side apps, then route it to a wide array of customer tools and data warehouses.
+    - <Link to="/cloud-extract-sources">Cloud Extract</Link>: Build ELT pipelines from cloud apps to your data warehouse.
+    - <Link to="/reverse-etl">Reverse ETL</Link>: Leverage your warehouse as a data source for your entire customer data stack.
 
 5. Once you have configured the data source, you will see the following source details page.
 
@@ -44,12 +44,12 @@ Note the source <strong>Write key</strong>. This is required for integrating the
 
 <img src="../assets/get-started/adding-new-destination.png" alt="Adding a new destination" />
 
-7. From the list of destinations, select the destination you want to configure for the source. RudderStack currently supports **over 150** destinations, including [event stream](https://www.rudderstack.com/docs/destinations/) and [warehouse](https://www.rudderstack.com/docs/data-warehouse-integrations/) destinations.
-8. Configure the destination by entering the relevant connection settings. For detailed information on these settings, refer to the destination-specific [documentation](https://rudderstack.com/docs/destinations/).
+7. From the list of destinations, select the destination you want to configure for the source. RudderStack currently supports **over 150** destinations, including <Link to="/destinations">Event Stream</Link> and <Link to="/data-warehouse-integrations">Warehouse</Link> destinations.
+8. Configure the destination by entering the relevant connection settings. For detailed information on these settings, refer to the <Link to="/destinations">destination-specific documentation</Link>.
 
 <div class="successBlock">
 
-You can also transform your events in RudderStack before sending them to the destinations. Read the <a href="https://rudderstack.com/docs/transformations/">Transformations</a> guide for more information on this feature.
+You can also transform your events in RudderStack before sending them to the destinations. Read the <Link to="/transformations/">Transformations</Link> guide for more information on this feature.
 </div>
 
 ## Guides in this section
@@ -140,13 +140,13 @@ You can also transform your events in RudderStack before sending them to the des
 
 ## See also
 
-- [RudderStack Cloud](https://rudderstack.com/docs/rudderstack-cloud/): Familiarize yourself with RudderStack. Know more about sources, destinations, and connections.
-- [Glossary](https://rudderstack.com/docs/get-started/glossary/): Understand the definitions of the different terms that you are likely to encounter while using RudderStack.
-- [Sources](https://rudderstack.com/docs/rudderstack-cloud/sources/): Start tracking your event data by integrating RudderStack with your web, mobile, and server-side apps.
-- [Destinations](https://rudderstack.com/docs/rudderstack-cloud/destinations/): Send your event data to over 150 tool and warehouse destinations.
-- [Transformations](https://rudderstack.com/docs/transformations) : Customize the event data before routing it to your preferred destinations.
-- [Event spec](https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/): Plan your event data and explore various options for tracking your events across all the RudderStack SDKs and APIs.
-- [RudderStack API](https://www.rudderstack.com/docs/rudderstack-api/): Work with different RudderStack API depending on your use-case.
+- <Link to="/rudderstack-cloud">RudderStack Cloud</Link>: Familiarize yourself with RudderStack. Know more about sources, destinations, and connections.
+- <Link to="/get-started/glossary">Glossary</Link>: Understand the definitions of the different terms that you are likely to encounter while using RudderStack.
+- <Link to="/rudderstack-cloud/sources">Sources</Link>: Start tracking your event data by integrating RudderStack with your web, mobile, and server-side apps.
+- <Link to="/rudderstack-cloud/destinations">Destinations</Link>: Send your event data to over 150 tool and warehouse destinations.
+- <Link to="/transformations">Transformations</Link>: Customize the event data before routing it to your preferred destinations.
+- <Link to="/rudderstack-api/api-specification/rudderstack-spec/">RudderStack Event Spec</Link>: Plan your event data and explore various options for tracking your events across all the RudderStack SDKs and APIs.
+- <Link to="/rudderstack-api/">RudderStack API</Link>: Work with different RudderStack API depending on your use-case.
 
 ## Contact us
 

--- a/docs/get-started/rudderstack-architecture.mdx
+++ b/docs/get-started/rudderstack-architecture.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # RudderStack Architecture
 
-RudderStack is a stand-alone system dependent only on a database (**PostgreSQL**). Its backend is written in Go, with a rich UI written in React.js.
+RudderStack is a standalone system dependent only on a database (**PostgreSQL**). Its backend is written in Go, with a rich UI written in React.js.
 
 RudderStack's architecture consists of 2 major components: the **control plane** and **data plane**, as seen in the following diagram:
 
@@ -15,24 +15,24 @@ RudderStack's architecture consists of 2 major components: the **control plane**
 
 ## Control plane
 
-The control plane offers a UI to configure your event data sources and destinations. It comprises of:
+The control plane offers a UI to configure your event data sources and destinations. It consists of:
 
-- **RudderStack web app**: This is the [front-end application](https://app.rudderstack.com) that lets you set up your data pipelines in RudderStack.
+- **RudderStack web app**: The [front-end application](https://app.rudderstack.com) where you set up and configure your data pipelines in RudderStack. 
 - **Configuration backend**: The web app leverages this module to store all the relevant information around your configured sources, destinations, and the connections between them.
 
 ## Data plane
 
-The data plane(backend) is RudderStack's core engine responsible for:
+The data plane (backend) is RudderStack's core engine responsible for:
 
-- Receiving and processing the event data
-- Transforming the events in the required destination format
-- Relaying the events to the destination
+- Receiving and processing event data
+- Transforming events in the required destination format
+- Relaying events to the destination
 
 The RudderStack data plane consists of three major components:
 
 - RudderStack server ([rudder-server](https://github.com/rudderlabs/rudder-server))
 - Transformations module
-- Standalone streaming database(PostgreSQL) for the event data
+- Standalone streaming database (PostgreSQL) for event data
 
 <div class="infoBlock">
 
@@ -41,23 +41,23 @@ Refer to the <a href="#data-plane-architecture">data plane architecture</a> sect
 
 ## Data plane architecture
 
-RudderStack's data plane is responsible for receiving, transforming, and routing the event data to the destination. To do so, it receives the event data from sources like websites, mobile apps, server-side applications, cloud apps, and data warehouses.
+RudderStack's data plane is responsible for receiving, transforming, and routing event data to the destination. To do so, it receives the event data from sources like websites, mobile apps, server-side applications, cloud apps, and data warehouses.
 
 A simplified version of the RudderStack data plane architecture is as shown:
 
 <img src="../assets/get-started/rudderstack-backend-architecture.png" alt="RudderStack backend architecture" />
 
-The following sections give a detailed overview of each of the components of the RudderStack data plane.
+The following sections give an overview of each of the components of the RudderStack data plane.
 
 ### Gateway
 
-The gateway module is primarily responsible for receiving the event data from a source (web, mobile, or server-side) and forwarding it for processing and transformation. 
+The gateway module is primarily responsible for receiving event data from a source (web, mobile, or server-side) and forwarding it for processing and transformation. 
 
-It accepts the event requests and sends an acknowledgment back to the source depending on the acceptance (HTTP 200 response) or rejection of the event data.
+It accepts event requests and sends an acknowledgment back to the source depending on the acceptance (HTTP 200 response) or rejection of the event data.
 
 <div class="infoBlock">
 
-The gateway rejects the event data in case of the following scenarios:
+The gateway rejects event data in case of the following scenarios:
 <ul>
 <li>Invalid JSON</li>
 <li>Invalid write key</li>
@@ -65,24 +65,24 @@ The gateway rejects the event data in case of the following scenarios:
 </ul>
 </div>
 
-The gateway also temporarily stores all the received event data into an internal PostgreSQL database before acknowledging successful receipt. Once the event is successfully sent to the destination, it is then deleted from the database.
+The gateway also temporarily stores all received event data into an internal PostgreSQL database before acknowledging successful receipt. Once event is successfully sent to the destination, it is then deleted from the database.
 
 ### Processor
 
-The processor fetches the data from the gateway and forwards it to the transformation module. Once the event data is transformed, the processor forwards it to the router module that sends it to the required destination.
+The processor fetches data from the gateway and forwards it to the transformation module. Once event data is transformed, the processor forwards it to the router module that sends it to the required destination.
  
 ### Transformation module
 
-RudderStack's Transformations module transforms the received event data into a suitable destination-specific format. All the transformation codes are written in JavaScript.
+RudderStack's Transformations module transforms received event data into a suitable destination-specific format. All the transformation code is written in JavaScript.
 
-RudderStack also supports **user transformations** that let you code custom JavaScript functions to implement specific use-cases on your event data. These include - but are not limited to - event enrichment, filtering, removing sensitive PII information, etc.
+RudderStack also supports **user transformations** that let you code custom JavaScript functions to implement specific use-cases on your event data. These include but are not limited to: event enrichment, filtering, removing sensitive PII information, etc.
 
 <div class="successBlock">
 
-  Refer to the <a href="https://rudderstack.com/docs/transformations/">RudderStack Transformations</a> guide for more information on the user transformations.
+  Refer to the <Link to="/transformations">RudderStack Transformations</Link> guide for more information on user transformations.
 </div>
 
-Once the events are transformed, the transformation module sends them back to the processor. The processor then forwards this data to the router, which in turn relays it to the desired destination.
+Once events are transformed, the transformation module sends them back to the processor. The processor then forwards this data to the router, which in turn relays it to the desired destination.
 
 ### Router
 
@@ -101,16 +101,19 @@ RudderStack does not persist any events or store any user information in the dat
 
 The following steps detail the RudderStack data plane workflow:
 
-1. The gateway module receives the event data from the source.
+1. The gateway module receives event data from the source.
 2. The gateway then:
-    - Stores the event data to the router database \(PostgreSQL\).
+    - Stores event data in the router database (PostgreSQL).
     - Sends an **HTTP 200** status acknowledging receipt of the data.
 3. The processor module picks the data from the gateway and forwards it to the transformation module.
 4. The transformation module transforms the event and sends it back to the processor.
 5. The processor forwards the transformed event to the router. This event is then deleted from the gateway store.
 6. The router then:
+
    i. Sends the transformed event data to the specified destinations.
+
    ii. Stores the event information in a separate table in the database.
+
 7. Once the event data reaches the destination, the router deletes it from the database.
 
 <img src="../assets/get-started/rudderstack-backend-workflow.png" alt="RudderStack Backend Workflow" />
@@ -119,11 +122,11 @@ The following steps detail the RudderStack data plane workflow:
 
 Although the default configuration works just fine for most use cases, RudderStack also gives you the flexibility to customize the data plane with a variety of configuration options. Some of these include backing up events to S3, rejecting malicious requests by defining the maximum size of the event, and more.
 
-You can do so by tweaking the [`config.yaml`](https://github.com/rudderlabs/rudder-server/blob/master/config/config.yaml) file to suit your application's needs.
+You can do so by editing the [`config.yaml`](https://github.com/rudderlabs/rudder-server/blob/master/config/config.yaml) file to suit your application's needs.
 
 <div class="infoBlock">
 
-Refer to the <a href="https://rudderstack.com/docs/user-guides/administrators-guide/config-parameters">Configuration Parameters</a> guide for more information on these configuration options.
+Refer to the <Link to="/user-guides/administrators-guide/config-parameters">Configuration Parameters</Link> guide for more information on these configuration options.
 </div>
 
 ## Contact us


### PR DESCRIPTION
## Description of the change

- uses Gatsby link for internal links
- copy edit
- use unicode for tables   ❌   ✅ 

Preview: 
- https://deploy-preview-586--rudderstack-docs-staging.netlify.app/get-started/cloud-vs-open-source/
- https://deploy-preview-586--rudderstack-docs-staging.netlify.app/get-started/rudderstack-architecture/

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance

## Related issues

n/a

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
