### PR TITLE
Algolia testing [DRAFT]

### DIFF
--- a/docs/get-started/cool.mdx
+++ b/docs/get-started/cool.mdx
@@ -1,0 +1,19 @@
+---
+title: "Cool title from frontmatter"
+description: >-
+  Neat description
+aliases: ["baz", "lurhmann"]
+tags: "awesome"
+---
+
+# Cool h1, not to be confused with the cool title
+
+Cool excerpts are neat.
+
+## Headings are important
+
+Content is important too.
+
+### This is an h3
+
+can you see my h3?

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,13 +119,13 @@ module.exports = {
             options: {
               appId: process.env.GATSBY_ALGOLIA_APP_ID,
               apiKey: process.env.RS_GATSBY_ALGOLIA_APIKEY,
-              indexName:
-                process.env.GATSBY_ALGOLIA_INDEX_PREFIX + "_gatsby_docs",
-              queries: require("./src/utils/docs-algolia"),
-              enablePartialUpdates: true,
+              indexName: "pfd",
+              queries: require("./src/utils/algolia-queries"),
+              enablePartialUpdates: false,
               matchFields: [
                 "pageSlug",
                 "pageTitle",
+                "title",
                 "sectionTitle",
                 "sectionId",
                 "sectionContent",

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,7 +119,7 @@ module.exports = {
             options: {
               appId: process.env.GATSBY_ALGOLIA_APP_ID,
               apiKey: process.env.RS_GATSBY_ALGOLIA_APIKEY,
-              indexName: "pfd",
+              indexName: process.env.GATSBY_ALGOLIA_INDEX,
               queries: require("./src/utils/docs-algolia"),
               enablePartialUpdates: false,
               matchFields: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -120,7 +120,7 @@ module.exports = {
               appId: process.env.GATSBY_ALGOLIA_APP_ID,
               apiKey: process.env.RS_GATSBY_ALGOLIA_APIKEY,
               indexName: "pfd",
-              queries: require("./src/utils/algolia-queries"),
+              queries: require("./src/utils/docs-algolia"),
               enablePartialUpdates: false,
               matchFields: [
                 "pageSlug",

--- a/src/components/DocsNavigation.js
+++ b/src/components/DocsNavigation.js
@@ -1,21 +1,20 @@
-import React, { useState } from "react"
-import RsLogo from "../images/rudderstack-logo-v2.svg"
-import { InstantSearch, Configure } from "react-instantsearch-dom"
-import algoliasearch from "algoliasearch/lite"
-import DocsSearchBox from "./DocsSearchBox"
-import DocSearchContentWrapper from "./DocSearchContentWrapper"
-import {rudderslabTrackOnClickDocs} from '../utils/common'
+import React, { useState } from "react";
+import RsLogo from "../images/rudderstack-logo-v2.svg";
+import { InstantSearch, Configure } from "react-instantsearch-dom";
+import algoliasearch from "algoliasearch/lite";
+import DocsSearchBox from "./DocsSearchBox";
+import DocSearchContentWrapper from "./DocSearchContentWrapper";
+import { rudderslabTrackOnClickDocs } from "../utils/common";
 
 const searchClient = algoliasearch(
   process.env.GATSBY_ALGOLIA_APP_ID,
   process.env.GATSBY_ALGOLIA_SEARCH_APIKEY
-)
+);
 
-
-const DocsNavigation = ({ isMenuOpen, handleMenuOpen}) => {
-  const [isSearchOpen, setSearchOpen] = useState(false)
-  const [currentSearchText, setCurrentSearchText] = useState("")
-  const [currentRefineHitsCount, setCurrentRefineHitsCount] = useState(0)
+const DocsNavigation = ({ isMenuOpen, handleMenuOpen }) => {
+  const [isSearchOpen, setSearchOpen] = useState(false);
+  const [currentSearchText, setCurrentSearchText] = useState("");
+  const [currentRefineHitsCount, setCurrentRefineHitsCount] = useState(0);
 
   return (
     <div className="headerNav">
@@ -37,23 +36,54 @@ const DocsNavigation = ({ isMenuOpen, handleMenuOpen}) => {
           </svg>
         </div>
         <div className="docsLogo flex items-center">
-          <a href="https://www.rudderstack.com/" onClick={(e) => rudderslabTrackOnClickDocs("navigation", null, e, true)}>
+          <a
+            href="https://www.rudderstack.com/"
+            onClick={(e) =>
+              rudderslabTrackOnClickDocs("navigation", null, e, true)
+            }
+          >
             <img src={RsLogo} alt="RudderStack" className="mainLogo" />
           </a>
         </div>
         <nav className="docsNav">
           <ul className="docsNavList">
             <li>
-              <a href="/" onClick={(e) => rudderslabTrackOnClickDocs("navigation", null, e, true)}>Home</a>
+              <a
+                href="/"
+                onClick={(e) =>
+                  rudderslabTrackOnClickDocs("navigation", null, e, true)
+                }
+              >
+                Home
+              </a>
             </li>
             <li>
-              <a href="https://github.com/rudderlabs/rudder-server" onClick={(e) => rudderslabTrackOnClickDocs("navigation", null, e, true)}>GitHub</a>
+              <a
+                href="https://github.com/rudderlabs/rudder-server"
+                onClick={(e) =>
+                  rudderslabTrackOnClickDocs("navigation", null, e, true)
+                }
+              >
+                GitHub
+              </a>
             </li>
             <li>
-              <a href="https://www.rudderstack.com/pricing" onClick={(e) => rudderslabTrackOnClickDocs("navigation", null, e, true)}>Pricing</a>
+              <a
+                href="https://www.rudderstack.com/pricing"
+                onClick={(e) =>
+                  rudderslabTrackOnClickDocs("navigation", null, e, true)
+                }
+              >
+                Pricing
+              </a>
             </li>
             <li>
-              <a href="https://app.rudderstack.com/signup?type=freetrial" onClick={(e) => rudderslabTrackOnClickDocs("navigation", null, e, true)}>
+              <a
+                href="https://app.rudderstack.com/signup?type=freetrial"
+                onClick={(e) =>
+                  rudderslabTrackOnClickDocs("navigation", null, e, true)
+                }
+              >
                 Try for Free
               </a>
             </li>
@@ -80,44 +110,57 @@ const DocsNavigation = ({ isMenuOpen, handleMenuOpen}) => {
               </g>
             </svg>
           </span>
-          <input type="text" placeholder="Search..." className="docsSearchbar" onClickCapture={(e) => {setSearchOpen(true); e.target.blur();}} />
+          <input
+            type="text"
+            placeholder="Search..."
+            className="docsSearchbar"
+            onClickCapture={(e) => {
+              setSearchOpen(true);
+              e.target.blur();
+            }}
+          />
         </div>
-        
+
         <div className="searchWrapper">
-          <div className={`searchOverlay ${isSearchOpen ? 'active' : ''}`} onClick={() => setSearchOpen(false)}></div>
-          <div className={`instantSearchWrapper ${isSearchOpen ? 'active' : ''}`}>
-              <InstantSearch
-                searchClient={searchClient}
-                indexName={process.env.GATSBY_ALGOLIA_INDEX_PREFIX + "_gatsby_docs"}
-              >
-                <Configure hitsPerPage={10} />
-                <div className="docsSearchWrapper">
-                  <DocsSearchBox
-                    onRefineTextChange={val => {
-                      setCurrentSearchText(val);
-                    }}
+          <div
+            className={`searchOverlay ${isSearchOpen ? "active" : ""}`}
+            onClick={() => setSearchOpen(false)}
+          ></div>
+          <div
+            className={`instantSearchWrapper ${isSearchOpen ? "active" : ""}`}
+          >
+            <InstantSearch
+              searchClient={searchClient}
+              indexName={process.env.GATSBY_ALGOLIA_INDEX}
+            >
+              <Configure hitsPerPage={10} />
+              <div className="docsSearchWrapper">
+                <DocsSearchBox
+                  onRefineTextChange={(val) => {
+                    setCurrentSearchText(val);
+                  }}
+                  isSearchOpen={isSearchOpen}
+                  currentSearchText={currentSearchText}
+                  setSearchOpen={setSearchOpen}
+                />
+              </div>
+              <div id="docsSearchHitsContainer">
+                <div data-reactroot>
+                  <DocSearchContentWrapper
                     isSearchOpen={isSearchOpen}
+                    onRefineHitsCountChange={setCurrentRefineHitsCount}
                     currentSearchText={currentSearchText}
                     setSearchOpen={setSearchOpen}
+                    currentRefineHitsCount={currentRefineHitsCount}
                   />
                 </div>
-                <div id="docsSearchHitsContainer">
-                  <div data-reactroot>
-                    <DocSearchContentWrapper
-                      isSearchOpen={isSearchOpen}
-                      onRefineHitsCountChange={setCurrentRefineHitsCount}
-                      currentSearchText={currentSearchText}
-                      setSearchOpen={setSearchOpen}
-                      currentRefineHitsCount={currentRefineHitsCount}
-                    />
-                  </div>
-                </div>
-              </InstantSearch>
-            </div>
+              </div>
+            </InstantSearch>
+          </div>
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default DocsNavigation
+export default DocsNavigation;

--- a/src/utils/docs-algolia.js
+++ b/src/utils/docs-algolia.js
@@ -1,4 +1,4 @@
-const indexName = `pfd`
+const indexName = process.env.GATSBY_ALGOLIA_INDEX;
 const docsQuery = `{
     docs: allMdx {
       edges {
@@ -20,27 +20,29 @@ const docsQuery = `{
         }
       }
     }
-  }`
-function pageToAlgoliaRecord({ node: { id, frontmatter, headings, fields, tableOfContents, excerpt } }) {
-    return {
-        objectID: id,
-        title: frontmatter.title,
-        slug: fields.slug,
-        tableOfContents,
-        excerpt,
-        tags: frontmatter.tags,
-        alias: frontmatter.aliases,
-        headings,
-        // SectionTitle: tableOfContents.items[0].title
-        SectionTitle: tableOfContents.items[0].title, // we should use frontmatter title instead
-    }
+  }`;
+function pageToAlgoliaRecord({
+  node: { id, frontmatter, headings, fields, tableOfContents, excerpt },
+}) {
+  return {
+    objectID: id,
+    title: frontmatter.title,
+    slug: fields.slug,
+    tableOfContents,
+    excerpt,
+    tags: frontmatter.tags,
+    alias: frontmatter.aliases,
+    headings,
+    // SectionTitle: tableOfContents.items[0].title
+    SectionTitle: tableOfContents.items[0].title, // we should use frontmatter title instead
+  };
 }
 const queries = [
-    {
-        query: docsQuery,
-        transformer: ({ data }) => data.docs.edges.map(pageToAlgoliaRecord),
-        indexName,
-        settings: { attributesToSnippet: [`excerpt:20`] },
-    },
-]
-module.exports = queries
+  {
+    query: docsQuery,
+    transformer: ({ data }) => data.docs.edges.map(pageToAlgoliaRecord),
+    indexName,
+    settings: { attributesToSnippet: [`excerpt:20`] },
+  },
+];
+module.exports = queries;

--- a/src/utils/docs-algolia.js
+++ b/src/utils/docs-algolia.js
@@ -1,152 +1,46 @@
+const indexName = `pfd`
 const docsQuery = `{
     docs: allMdx {
       edges {
         node {
-          slug
+          id
+          frontmatter {
+            aliases
+            title
+            tags
+          }
           headings(depth: h2) {
             value
           }
-          tableOfContents(maxDepth: 1)
-          excerpt(pruneLength: 50000)
-        }
-      }
-    }
-  
-    allSanityDocsSearchAlias {
-      edges {
-        node {
-          search_alias
-          search_text
-          id
-        }
-      }
-    }
-  }`;
-
-function convertToSlug(pData) {
-  return pData
-    .toLowerCase()
-    .replace(" ", "-")
-    .replace(/ /g, "-")
-    .replace(".", "")
-    .replace("?", "")
-    .replace(/[^\w-]+/g, "");
-}
-
-const queries = [
-  {
-    query: docsQuery,
-    transformer: ({ data }) => {
-      let tmpData = [];
-      let ignorePaths = [
-        "LICENSE",
-        "contributing",
-        ".github/pull_request_template",
-      ];
-      data.docs.edges.map((row) => {
-        const parsedSlug = row.node.slug.replace("docs/", "");
-        let tmpString = row.node.excerpt;
-        let strPos =
-          ignorePaths.indexOf(parsedSlug) === -1 &&
-          row.node.tableOfContents !== {}
-            ? tmpString.indexOf(row.node.tableOfContents.items[0].title)
-            : "";
-        let endPos = tmpString.indexOf(
-          row.node.headings.length > 0 ? row.node.headings[0].value : ""
-        );
-
-        let content = tmpString.substring(strPos, endPos - 1);
-
-        let tttmp = data.allSanityDocsSearchAlias.edges.find(
-          (kk) =>
-            kk.node.search_alias ===
-            convertToSlug(
-              ignorePaths.indexOf(parsedSlug) === -1
-                ? row.node.tableOfContents.items[0].title
-                : ignorePaths[ignorePaths.indexOf(parsedSlug)]
-            )
-        );
-
-        let searchAlias = "";
-        if (tttmp) {
-          searchAlias = tttmp.node.search_text;
-        }
-
-        tmpString = tmpString.replace(content, "");
-        tmpData.push({
-          objectID:
-            parsedSlug +
-            "-" +
-            convertToSlug(
-              ignorePaths.indexOf(parsedSlug) === -1
-                ? row.node.tableOfContents.items[0].title
-                : "0"
-            ),
-          pageSlug: parsedSlug,
-          pageTitle:
-            ignorePaths.indexOf(parsedSlug) === -1
-              ? row.node.tableOfContents.items[0].title
-              : ignorePaths[ignorePaths.indexOf(parsedSlug)],
-          sectionId: convertToSlug(
-            ignorePaths.indexOf(parsedSlug) === -1
-              ? row.node.tableOfContents.items[0].title
-              : ignorePaths[ignorePaths.indexOf(parsedSlug)]
-          ),
-          SectionTitle: convertToSlug(
-            ignorePaths.indexOf(parsedSlug) === -1
-              ? row.node.tableOfContents.items[0].title
-              : ignorePaths[ignorePaths.indexOf(parsedSlug)]
-          ),
-          sectionContent: content,
-          searchAlias: searchAlias,
-          idx: 1,
-        });
-
-        for (var i = 0; i <= row.node.headings.length - 1; i += 1) {
-          strPos = 0;
-          endPos = 0;
-          content = "";
-
-          strPos = tmpString.indexOf(row.node.headings[i].value);
-
-          endPos =
-            i === row.node.headings.length - 1
-              ? tmpString.length
-              : tmpString.indexOf(row.node.headings[i + 1].value);
-
-          content = tmpString.substring(strPos, endPos - 1);
-          tmpString = tmpString.replace(content, "");
-
-          let tttmp = data.allSanityDocsSearchAlias.edges.find(
-            (kk) => kk.node.search_alias === row.node.headings[i].value
-          );
-
-          let searchAlias = "";
-          if (tttmp) {
-            searchAlias = tttmp.node.search_text;
+          fields {
+            slug
           }
-
-          tmpData.push({
-            objectID:
-              parsedSlug + "-" + convertToSlug(row.node.headings[i].value),
-            pageSlug: parsedSlug,
-            pageTitle:
-              ignorePaths.indexOf(parsedSlug) === -1
-                ? row.node.tableOfContents.items[0].title
-                : ignorePaths[ignorePaths.indexOf(parsedSlug)],
-            sectionId: convertToSlug(row.node.headings[i].value),
-            SectionTitle: row.node.headings[i].value,
-            sectionContent: content,
-            searchAlias: searchAlias,
-            idx: i + 2,
-          });
+          tableOfContents(maxDepth: 1)
+          excerpt(pruneLength: 200)
         }
-      });
-      return tmpData;
+      }
+    }
+  }`
+function pageToAlgoliaRecord({ node: { id, frontmatter, headings, fields, tableOfContents, excerpt } }) {
+    return {
+        objectID: id,
+        title: frontmatter.title,
+        slug: fields.slug,
+        tableOfContents,
+        excerpt,
+        tags: frontmatter.tags,
+        alias: frontmatter.aliases,
+        headings,
+        // SectionTitle: tableOfContents.items[0].title
+        SectionTitle: tableOfContents.items[0].title, // we should use frontmatter title instead
+    }
+}
+const queries = [
+    {
+        query: docsQuery,
+        transformer: ({ data }) => data.docs.edges.map(pageToAlgoliaRecord),
+        indexName,
+        settings: { attributesToSnippet: [`excerpt:20`] },
     },
-    indexName: process.env.GATSBY_ALGOLIA_INDEX_PREFIX + "_gatsby_docs",
-    settings: {},
-  },
-];
-
-module.exports = queries;
+]
+module.exports = queries


### PR DESCRIPTION
## Description of the change

- uses a straightforward graphql query to create the index/records for sending to Algolia for site search
- Cuts the number of records down to 324 from about 2300 since it's not creating an individual record for each header
- For RudderStack employees, you can view and test the `pfd` index in the Algolia dashboard. `gatsby build` will update the index if you are testing


TODOs:

- [ ] disentangle Heading from body content in the `excerpt` field
- [ ] Create a better search UI that shows minimally the header/title + the excerpt in search results. Nice to have: some concept of the Section the result is in, e.g. "Getting Started" - or a breadcrumb.
- [ ] remove the hardcoded pfd index and revert back to dev/prod naming convention
- [ ] remove all `# slug: /path` frontmatter entries in mdx 






---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202319482598448
  - https://app.asana.com/0/0/1202319482598456