### PR TITLE
Event size limits across RudderStack SDKs

### DIFF
--- a/docs/rudderstack-api/http-api.mdx
+++ b/docs/rudderstack-api/http-api.mdx
@@ -77,7 +77,20 @@ In case of the Invalid Authorization Header error, verify if the source write ke
 
 ## 4. Maximum Allowed Request Size
 
-RudderStack allows messages with a maximum size of `32 KB` per call. The [**`batch`**](https://rudderstack.com/docs/rudderstack-api/http-api#11-batch) endpoint accepts a maximum call size of `4 MB` per batch, and `32 KB` per call. RudderStack responds with a `400 Bad Request` if these limits are exceeded.
+### Client-side SDKs
+
+In case of client-side SDKs, RudderStack allows events with a maximum size of `32 KB` per call. The [**`batch`**](https://rudderstack.com/docs/rudderstack-api/http-api#11-batch) endpoint accepts a maximum call size of `4 MB` per batch and `32 KB` per call. 
+
+RudderStack responds with a `400 Bad Request` if these limits are exceeded.
+
+### Server-side SDKs
+
+In case of server-side SDKs, RudderStack supports maximum event size `4 MB`. Also, the [**`batch`**](https://rudderstack.com/docs/rudderstack-api/http-api#11-batch) endpoint accepts a maximum call size of `4 MB`.
+
+<div class="infoBlock">
+
+You can use the server-side SDKs to send a single event of 4 MB or batch multiple events as long as the total `batch` call size is less than or equal to 4 MB. The 4 MB limit must not be breached, otherwise RudderStack responds with a <code class="inline-code">400 Bad Request</code> error.
+</div>
 
 ## 5. Identify
 
@@ -574,7 +587,7 @@ For more details on the `alias` call, refer to the [**RudderStack Events Specifi
 
 The `batch` call allows you to send a series of `identify`, `track`, `page`, `group` and `screen` requests in a single batch. This call helps you minimize the number of outbound requests, thus enabling better performance.
 
-As mentioned earlier, RudderStack sets a maximum limit of `4 MB` per batch request and `32 KB` per call.
+RudderStack sets a maximum limit of `4 MB` per `batch` request and `32 KB` per call in case of client-side SDKs, whereas the server-side SDKs support a maximum limit of `4 MB` per call or `batch` request.
 
 * Request Type: **POST**
 * Request Format**:** 

--- a/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/js-sdk-faqs.mdx
+++ b/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/js-sdk-faqs.mdx
@@ -58,7 +58,9 @@ To check if data is being transmitted to the specified destinations, go to the *
 
 ## What is the size limit on the requests?
 
-The size limit on requests is 32KB per message and 4MB per batch request.
+RudderStack allows events with a maximum size of `32 KB` per call. The [**`batch`**](https://rudderstack.com/docs/rudderstack-api/http-api#11-batch) endpoint accepts a maximum call size of `4 MB` per batch and `32 KB` per call. 
+
+RudderStack responds with a `400 Bad Request` if these limits are exceeded.
 
 ## Can I send the event data to specific destinations only?
 

--- a/docs/stream-sources/rudderstack-sdk-integration-guides/sdk-faqs.mdx
+++ b/docs/stream-sources/rudderstack-sdk-integration-guides/sdk-faqs.mdx
@@ -8,6 +8,23 @@ description: Answers to the generally asked questions related to the RudderStack
 
 ## FAQs
 
+### What is the maximum event size supported by the RudderStack SDKs?
+
+#### Client-side SDKs
+
+In case of client-side SDKs, RudderStack allows events with a maximum size of `32 KB` per call. The [**`batch`**](https://rudderstack.com/docs/rudderstack-api/http-api#11-batch) endpoint accepts a maximum call size of `4 MB` per batch and `32 KB` per call. 
+
+RudderStack responds with a `400 Bad Request` if these limits are exceeded.
+
+#### Server-side SDKs
+
+In case of server-side SDKs, RudderStack supports a maximum event size of `4 MB`. Also, the [**`batch`**](https://rudderstack.com/docs/rudderstack-api/http-api#11-batch) endpoint accepts a maximum call size of `4 MB`.
+
+<div class="infoBlock">
+
+You can use the server-side SDKs to send a single event of 4 MB or batch multiple events as long as the total `batch` call size is less than or equal to 4 MB. The 4 MB limit must not be breached, otherwise RudderStack responds with a <code class="inline-code">400 Bad Request</code> error.
+</div>
+
 ### How does RudderStack handle **`anonymousId` ?**
 
 The following are the different ways in which RudderStack handles **`anonymousId`** across different SDKs:


### PR DESCRIPTION
## Description of the change

> Updated event size limits for the client-side and server-side SDKs across multiple docs.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Event size limit](https://www.notion.so/rudderstacks/Update-the-event-size-limits-for-client-side-and-server-side-SDKs-64ffbba6a68c4fa18849697c952ad871)
