### PR TITLE
Standardize pro/enterprise labels across docs

### DIFF
--- a/docs/data-governance/index.mdx
+++ b/docs/data-governance/index.mdx
@@ -16,7 +16,7 @@ In reality, however, as multiple stakeholders define and implement the event spe
 - **Capitalization/Casing errors** - For example, one event sets the product name in the lower case, while another sets it in the upper case.
 - **Unit errors** - For example, one event tracks the revenue in pounds, while another tracks it in dollars.
 
-<a href="https://rudderstack.com/pricing" target="_blank">
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
 <img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
 </a>
 

--- a/docs/data-governance/index.mdx
+++ b/docs/data-governance/index.mdx
@@ -16,6 +16,10 @@ In reality, however, as multiple stakeholders define and implement the event spe
 - **Capitalization/Casing errors** - For example, one event sets the product name in the lower case, while another sets it in the upper case.
 - **Unit errors** - For example, one event tracks the revenue in pounds, while another tracks it in dollars.
 
+<a href="https://rudderstack.com/pricing" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
+
 ## RudderStack Data Governance API
 
 RudderStack's [**Data Governance API**](https://rudderstack.com/docs/data-governance/rudderstack-data-governance-api/) gives you the ability to access all your events and their metadata programmatically. This includes vital information related to the event schema, event payload versions, data types, and more.

--- a/docs/data-governance/index.mdx
+++ b/docs/data-governance/index.mdx
@@ -62,3 +62,4 @@ Refer to this <a href="https://rudderstack.com/blog/rudderstacks-data-governance
 ## Contact us
 
 For queries on any of the sections covered in this guide, you can [**contact us**](mailto:%20docs@rudderstack.com) or start a conversation in our [**Slack**](https://rudderstack.com/join-rudderstack-slack-community) community.
+

--- a/docs/data-governance/rudder-typer.mdx
+++ b/docs/data-governance/rudder-typer.mdx
@@ -8,9 +8,13 @@ description: >-
 
 # RudderTyper
 
-[**RudderTyper**](https://github.com/rudderlabs/rudder-typer) is a tool that lets you generate strongly-typed [**RudderStack**](https://rudderstack.com/) analytics library wrappers based on your [**Tracking Plan**](https://documenter.getpostman.com/view/16242548/TzeWFT6D) spec.
+[**RudderTyper**](https://github.com/rudderlabs/rudder-typer) is a tool that lets you generate strongly-typed [**RudderStack**](https://rudderstack.com/) analytics library wrappers based on your [**Tracking Plan**](https://documenter.getpostman.com/view/16242548/TzeWFT6D) spec. <br /><br />
 
 Simply put, it uses an event from your specified tracking plan and generates an analytics call in the supported languages.
+
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
 
 <div class="successBlock">
 

--- a/docs/data-governance/rudderstack-data-governance-api.mdx
+++ b/docs/data-governance/rudderstack-data-governance-api.mdx
@@ -12,7 +12,9 @@ The RudderStack Data Governance API gives you full access to all your events' me
 
 This documentation describes all of the available calls in the Data Governance API, as well as the properties of the returned objects as a result.
   
-[![Plan: Enterprise](https://img.shields.io/static/v1?label=PLAN&message=ENTERPRISE&color=blueviolet&style=for-the-badge)](https://rudderstack.com/enterprise-quote)
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
 
 ## Getting Started - Obtaining the Credentials
 

--- a/docs/data-governance/ruddertyper.mdx
+++ b/docs/data-governance/ruddertyper.mdx
@@ -7,7 +7,13 @@ description: >-
 
 # RudderTyper
 
-[RudderTyper](https://github.com/rudderlabs/rudder-typer) is a tool that lets you generate strongly-typed analytics library wrappers based on your [Tracking Plans](https://www.rudderstack.com/docs/data-governance/tracking-plans/). Simply put, it uses an event from your specified tracking plan and generates an analytics call in the supported languages.
+[RudderTyper](https://github.com/rudderlabs/rudder-typer) is a tool that lets you generate strongly-typed analytics library wrappers based on your [Tracking Plans](https://www.rudderstack.com/docs/data-governance/tracking-plans/). 
+
+Simply put, it uses an event from your specified tracking plan and generates an analytics call in the supported languages.
+
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Pro/Enterprise&color=blueviolet" class="githubBadge" />
+</a>
 
 <div class="successBlock">
 

--- a/docs/data-governance/ruddertyper.mdx
+++ b/docs/data-governance/ruddertyper.mdx
@@ -11,7 +11,7 @@ description: >-
 
 Simply put, it uses an event from your specified tracking plan and generates an analytics call in the supported languages.
 
-<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<a href="https://www.rudderstack.com/pricing/" target="_blank">
 <img src="https://img.shields.io/static/v1?label=Plan&message=Pro/Enterprise&color=blueviolet" class="githubBadge" />
 </a>
 

--- a/docs/data-governance/tracking-plans/index.mdx
+++ b/docs/data-governance/tracking-plans/index.mdx
@@ -9,6 +9,10 @@ description: >-
 
 Tracking Plans let you proactively monitor and act on non-compliant event data coming into your RudderStack sources based on predefined plans. This can help you prevent or de-risk situations where missing or improperly configured event data can break your downstream destinations.
 
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
+
 ## Tracking Plan features
 
 With the help of a Tracking Plan, you can:

--- a/docs/identity-resolution.mdx
+++ b/docs/identity-resolution.mdx
@@ -15,6 +15,10 @@ With RudderStack's warehouse-first architecture, you can send all your cross-pla
 
 This guide walks you through RudderStack's identity resolution feature in detail.
 
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
+
 ## How identity resolution works
 
 Identity resolution involves the usage of an **identity graph** - a database that houses and brings together all the different user identifiers throughout their journey into a single customer view. The identity graph collects and continually updates the customer profile with multiple identifiers mentioned above, like email, phone number, device IDs, etc.

--- a/docs/rudderstack-api/data-regulation-api.mdx
+++ b/docs/rudderstack-api/data-regulation-api.mdx
@@ -17,7 +17,7 @@ The Data Regulation API is applicable only for the destinations configured to se
 </div>
 
 <a href="https://rudderstack.com/enterprise-quote" target="_blank">
-<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" alt="Github Badge" class="githubBadge" />
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
 </a>
 
 ## What is data regulation?

--- a/docs/rudderstack-cloud/audit-logs.mdx
+++ b/docs/rudderstack-cloud/audit-logs.mdx
@@ -13,6 +13,10 @@ description: Detailed description of the Audit Logs option in RudderStack Cloud.
 The Audit Logs feature is available for the enterprise plan users. For more information on this plan and its features, refer to the <a href="https://rudderstack.com/pricing/"><strong>RudderStack Pricing</strong></a> page.
 </div>
 
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
+
 ## Accessing the audit logs
 
 <div class="infoBlock">

--- a/docs/user-guides/administrators-guide/onelogin-sso.mdx
+++ b/docs/user-guides/administrators-guide/onelogin-sso.mdx
@@ -10,7 +10,9 @@ description: >-
 
 This document lists the steps to follow in order to configure and enable SSO for your organization with OneLogin.
 
-[![Plan: Enterprise](https://img.shields.io/static/v1?label=PLAN&message=ENTERPRISE&color=blueviolet&style=for-the-badge)](https://rudderstack.com/enterprise-quote)
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
 
 ## Configuring SSO
 

--- a/docs/user-guides/administrators-guide/rudderstack-grafana-dashboard.mdx
+++ b/docs/user-guides/administrators-guide/rudderstack-grafana-dashboard.mdx
@@ -12,6 +12,10 @@ All the performance metrics are stored in InfluxDB, where Grafana queries them a
 
 This guide is aimed at explaining these performance metrics and the various dashboard panels in detail.
 
+<a href="https://rudderstack.com/enterprise-quote" target="_blank">
+<img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
+</a>
+
 ## Terminology
 
 The following are some of the commonly used terms that you are likely to encounter in this guide:


### PR DESCRIPTION
## Description of the change

> Standardize the pro/enterprise labels across all the relevant docs. Added missing labels for some docs on pro/enterprise features.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix

## Notion ticket link

> [Pro/Enterprise labels standardization](https://www.notion.so/rudderstacks/Pro-Enterprise-labels-standardization-d99a2d94e0dc49b3870c4ff5d8bc6524)
