### PR TITLE
Identity Resolution doc updates

### DIFF
--- a/docs/identity-resolution.mdx
+++ b/docs/identity-resolution.mdx
@@ -15,6 +15,11 @@ With RudderStack's warehouse-first architecture, you can send all your cross-pla
 
 This guide walks you through RudderStack's identity resolution feature in detail.
 
+<div class="infoBlock">
+
+Currently, RudderStack supports identity resolution only for the <Link to="data-warehouse-integrations/google-bigquery/">Google BigQuery</Link> and <Link to="https://www.rudderstack.com/docs/data-warehouse-integrations/snowflake/">Snowflake</Link> warehouse destinations.
+</div>
+
 <a href="https://rudderstack.com/enterprise-quote" target="_blank">
 <img src="https://img.shields.io/static/v1?label=Plan&message=Enterprise&color=blueviolet" class="githubBadge" />
 </a>


### PR DESCRIPTION
## Description of the change

> Added note that ID res is supported only for BigQuery and Snowflake.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [ID resolution doc updates](https://www.notion.so/rudderstacks/Identity-Resolution-support-call-out-in-the-docs-e3aa430bc14348cc8bc3abe502a0ab12)