### PR TITLE
LaunchDarkly documentation updates

### DIFF
--- a/docs/destinations/testing-and-personalization/launchdarkly.mdx
+++ b/docs/destinations/testing-and-personalization/launchdarkly.mdx
@@ -132,7 +132,7 @@ A sample `alias` call is shown below:
 rudderanalytics.alias("newUserId","userId");
 ```
 
-## FAQs
+## FAQ
 
 ### Where do I get the LaunchDarkly Client-side ID?
 


### PR DESCRIPTION
## Description of the change

> Standardized the LaunchDarkly doc
> Added the note explicitly stating that `identify` needs to be called before `track` or `alias`.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [LaunchDarkly doc updates](https://www.notion.so/rudderstacks/LaunchDarkly-doc-updates-eb24be14b5dc4a63bf4d20673311731f)