### PR TITLE
Auth0 source deprecation note

### DIFF
--- a/docs/stream-sources/auth0.mdx
+++ b/docs/stream-sources/auth0.mdx
@@ -4,41 +4,39 @@ title: "Auth0"
 description: Step-by-step guide to ingest your event data from Auth0 into RudderStack.
 ---
 
-[**Auth0**](https://auth0.com/) is a popular solution used by many companies to add authentication and authorization services to their applications. You can connect Auth0 to your application with just a few lines of code and also define the identity providers, i.e., how you want the users to log in.
+[Auth0](https://auth0.com/) is a popular solution used by many companies to add authentication and authorization services to their applications. You can now send login and signup-related events to RudderStack whenever Auth0 generates an authentication log by adding an [Auth0 Authentication API webhook](https://auth0.com/docs/extensions/auth0-authentication-api-webhooks) extension that points to RudderStack.
 
-You can now send login and signup-related events to RudderStack whenever Auth0 generates an authentication log by adding an [**Auth0 Authentication API webhook**](https://auth0.com/docs/extensions/auth0-authentication-api-webhooks) extension that points to RudderStack.
-
-This guide will help you set up Auth0 as a source in RudderStack.
+<div class="dangerBlock">
+Starting May 4, 2022, the recommended Authentication API webhook is no longer supported by Auth0. <strong>As a result, this integration is deprecated</strong>. For more information, refer to the <a href="https://auth0.com/docs/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-from-log-extensions#auth0-management-api-webhooks">Auth0 docs</a>.
+</div>
 
 ## Getting started
 
 Follow these steps to set up your Auth0 source in the RudderStack dashboard:
 
-- Go to your [**RudderStack dashboard**](https://app.rudderstack.com/) and click on **Add Source**. Then, select **Auth0** from the list of **Event Stream** sources, as shown:
+1. Go to your [RudderStack dashboard](https://app.rudderstack.com/) and click on **Add Source**. Then, select **Auth0** from the list of **Event Stream** sources, as shown:
 
 <img src="../assets/event-stream-sources/auth0-1.png" alt="Auth0 source in RudderStack" />
 
-- Assign a name to your source and click on **Next**.
-
-- Your Auth0 source is now configured. Note the source **Write key** - this will be required to configure the endpoint URL in the following steps.
+2. Assign a name to your source and click on **Next**.
+3. Your Auth0 source is now configured. Note the source **Write key** - this will be required to configure the endpoint URL in the following steps.
 
 <img src="../assets/event-stream-sources/auth0-2.png" alt="Auth0 source write key" />
 
-- Head over to your [**Auth0**](https://auth0.com/) account and navigate to the **Extensions** page from the sidebar.
-
-- Look for the extension **Auth0 Authentication API webhooks**, as shown:
+4. Head over to your [**Auth0**](https://auth0.com/) account and navigate to the **Extensions** page from the sidebar.
+5. Look for the extension **Auth0 Authentication API webhooks**, as shown:
 
 <img src="../assets/event-stream-sources/auth0-3.png" alt="Auth0 API webhook" />
 
-- After selecting this option, you should be able to see the extension installation page, as shown:
+6. After selecting this option, you should be able to see the extension installation page, as shown:
 
 <img src="../assets/event-stream-sources/auth0-4.png" alt="Auth0 extension installation page" />
 
-- At the bottom, select the **LOG_TYPES** option for which you want to forward the events to RudderStack.
+7. At the bottom, select the **LOG_TYPES** option for which you want to forward the events to RudderStack.
 
 <img src="../assets/event-stream-sources/auth0-5.png" alt="Auth0 log types" />
 
-- Add the **WEBHOOK_URL** as shown on the source settings page in your RudderStack dashboard.
+8. Add the **WEBHOOK_URL** as shown on the source settings page in your RudderStack dashboard.
 
 <img src="../assets/event-stream-sources/auth0-6.png" alt="Auth0 webhook URL" />
 
@@ -55,22 +53,18 @@ https://hosted.rudderlabs.com/v1/webhook?writeKey=1bCenS7ynqHh8ETX8s5Crjh22J
 ```
 
 <div class="infoBlock">
-
 For more information on the data plane URL, refer to <a href="https://rudderstack.com/docs/rudderstack-open-source/installing-and-setting-up-rudderstack/#what-is-a-data-plane-url-where-do-i-get-it">this</a> section.
 </div>
 
 <div class="warningBlock">
-
 Make sure you add the source write key as query parameter to the URL. This is required to prevent the webhook from failing because of an invalid write key.
 </div>
 
 Then, continue with the rest of the steps as listed below:
 
-- Keep the authorization section as blank.
-
-- You can disable the **SEND_AS_BATCH** setting to receive the events in separate requests. However, we recommend setting it to **Enabled**.
-
-- Finally click on **INSTALL** to install the webhook on your Auth0 dashboard.
+9. Keep the authorization section as blank.
+10. You can disable the **SEND_AS_BATCH** setting to receive the events in separate requests. However, we recommend setting it to **Enabled**.
+11. Finally click on **INSTALL** to install the webhook on your Auth0 dashboard.
 
 ## Event transformation
 
@@ -98,10 +92,9 @@ The following table lists the properties populated from the Auth0 event payload 
 If you're unable to see any events flowing from the Auth0 API webhooks to RudderStack, you can troubleshoot the issue by viewing the API webhooks logs. To do so, go to your Auth0 dashboard and navigate to **Monitoring** - **Logs**.
 
 <div class="infoBlock">
-
 Refer to the <a href="https://auth0.com/docs/extensions/auth0-authentication-api-webhooks#troubleshoot-webhooks">Auth0 documentation</a> for more information on troubleshooting your webhook.
 </div>
 
 ## Contact us
 
-For queries on any of the sections covered in this guide, you can [**contact us**](mailto:%20docs@rudderstack.com) or start a conversation in our [**Slack**](https://rudderstack.com/join-rudderstack-slack-community) community.
+For queries on any of the sections covered in this guide, you can [contact us](mailto:%20docs@rudderstack.com) or start a conversation in our [Slack](https://rudderstack.com/join-rudderstack-slack-community) community.


### PR DESCRIPTION
## Description of the change

> Added deprecation note for Auth0 source.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix

## Notion ticket link

> [Auth0 deprecation note](https://www.notion.so/rudderstacks/Auth0-source-deprecation-28645fb28d3a4e6f961fc0244d8bb987)