### PR TITLE
Rate limiting note

### DIFF
--- a/docs/destinations/advertising/google-adwords-enhanced-conversions.mdx
+++ b/docs/destinations/advertising/google-adwords-enhanced-conversions.mdx
@@ -7,8 +7,11 @@ description: Step-by-step guide to send event data from RudderStack to Google Ad
 
 RudderStack supports Google Adwords Enhanced Conversions as a destination to which you can send your audience list.
 
-<div class="warningBlock">
+<div class="dangerBlock">
+This destination is <strong>temporarily</strong> rate-limited and there is a possibility your events might not flow through. The RudderStack team is actively working on a fix for this issue. For any questions, <a href="mailto:%20support@rudderstack.com">contact us</a> or start a conversation in our <a href="https://rudderstack.com/join-rudderstack-slack-community">Slack</a> community.
+</div>
 
+<div class="infoBlock">
 To use this destination, you must set up Enhanced Conversions with the Google Ads API. For detailed instructions, refer to the <a href="https://support.google.com/google-ads/answer/11062876" target="_blank">Google Ads support page</a>.
 </div>
 

--- a/docs/destinations/advertising/google-adwords-remarketing-list.mdx
+++ b/docs/destinations/advertising/google-adwords-remarketing-list.mdx
@@ -7,6 +7,10 @@ description: Step-by-step guide to send event data from RudderStack to Google Ad
 
 RudderStack supports Google Adwords Remarketing Lists as a destination to which you can send your audience list.
 
+<div class="dangerBlock">
+This destination is <strong>temporarily</strong> rate-limited and there is a possibility your events might not flow through. The RudderStack team is actively working on a fix for this issue. For any questions, <a href="mailto:%20support@rudderstack.com">contact us</a> or start a conversation in our <a href="https://rudderstack.com/join-rudderstack-slack-community">Slack</a> community.
+</div>
+
 ## Getting started
 
 Before configuring Google Adwords Remarketing Lists as a destination in RudderStack, verify if the source platform is supported by referring to the table below:


### PR DESCRIPTION
## Description of the change

> Added rate limiting notes for GA Enhanced Conversions and Remarketing Lists destinations.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix

## Notion ticket link

> [Rate limiting note](https://www.notion.so/rudderstacks/Add-note-on-rate-limiting-a33b9c7cb64b4da8bbb1e25ae29404ad)