### PR TITLE
Warehouse destination image URL fixes

### DIFF
--- a/docs/tmp-destinations/warehouse-destinations/azure-datalake.mdx
+++ b/docs/tmp-destinations/warehouse-destinations/azure-datalake.mdx
@@ -8,12 +8,10 @@ description: Step-by-step guide on setting up Azure Data Lake as a destination i
 RudderStack lets you configure Azure data lake as a destination to which you can send your event data seamlessly.
 
 <div class="infoBlock">
-
 Refer to the <a href="https://rudderstack.com/docs/data-warehouse-integrations/warehouse-schemas/">Warehouse Schemas</a> guide for more information on how the events are mapped to the tables in the Azure data lake.
 </div>
 
 <div class="successBlock">
-
 Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/azure_datalake">GitHub repository</a>.
 </div>
 
@@ -28,19 +26,19 @@ To configure Azure data lake as a destination in RudderStack, follow these steps
 
 ### Connection settings
 
-<img src="../assets/dw-integrations/azure-datalake-1.png" alt="Azure data lake destination settings in RudderStack" />
+<img src="../../assets/dw-integrations/azure-datalake-1.png" alt="Azure data lake destination settings in RudderStack" />
 
 Enter the following credentials in the **Connection Credentials** page:
-    - **Azure Blob Storage Container Name**: The name of the Azure container used to store the data before loading it into the data lake.
-    - **Prefix**: If specified, RudderStack will create a folder in the bucket with this prefix and push all the data within that folder. For example, `https://<account_name>.blob.core.windows.net/<container_name>/<prefix>/`
-    - **Namespace**: If specified, all the data for the destination will be pushed to `https://<account_name>.blob.core.windows.net/<bucketName>/<prefix>/rudder-datalake/<namespace>`. If you don't specify a namespace in the settings, RudderStack sets it to the source name, by default.
-    - **Azure Blob Storage Account Name**:Your Azure Blob Storage account name.
-    - **Azure Blob Storage Account Key**: Your Azure Blob Storage account key.
-    - **Sync Frequency**: Specify how often RudderStack should sync the data to your Azure data lake.
-    - **Sync Starting At**: This optional setting lets you specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.
+
+- **Azure Blob Storage Container Name**: The name of the Azure container used to store the data before loading it into the data lake.
+- **Prefix**: If specified, RudderStack will create a folder in the bucket with this prefix and push all the data within that folder. For example, `https://<account_name>.blob.core.windows.net/<container_name>/<prefix>/`
+- **Namespace**: If specified, all the data for the destination will be pushed to `https://<account_name>.blob.core.windows.net/<bucketName>/<prefix>/rudder-datalake/<namespace>`. If you don't specify a namespace in the settings, RudderStack sets it to the source name, by default.
+- **Azure Blob Storage Account Name**:Your Azure Blob Storage account name.
+- **Azure Blob Storage Account Key**: Your Azure Blob Storage account key.
+- **Sync Frequency**: Specify how often RudderStack should sync the data to your Azure data lake.
+- **Sync Starting At**: This optional setting lets you specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.
 
 <div class="infoBlock">
-
 For more information on setting up your Azure Blob Storage account, refer to the <a href="https://rudderstack.com/docs/destinations/storage-platforms/microsoft-azure-blob-storage/#setting-up-azure-blob-storage">Azure Blob Storage</a> guide.
 </div>
 
@@ -60,7 +58,6 @@ As specified in the [Connnection settings](#connection-settings) section above:
 * `YYYY`, `MM`, `DD`, and `HH` are replaced by the actual time values.
 
 <div class="infoBlock">
-
 A combination of the <code class="inline-code">YYYY</code>, <code class="inline-code">MM</code>, <code class="inline-code">DD</code>, and <code class="inline-code">HH</code> values represents the UTC time.
 </div>
 
@@ -97,7 +94,6 @@ To enable network access to RudderStack, you will need to allowlist the followin
 - 3.64.201.167
 
 <div class="infoBlock">
-
 If you have your deployment in the EU region, you can allowlist only the following two IPs:
 <ul>
 <li>3.66.99.198</li>
@@ -106,7 +102,6 @@ If you have your deployment in the EU region, you can allowlist only the followi
 </div>
 
 <div class="infoBlock">
-
 All the outbound traffic is routed through these RudderStack IPs.
 </div>
 


### PR DESCRIPTION
## Description of the change

> Because of the folder restructuring, the relative image paths for the warehouse destinations have changed. This PR fixes the relative paths for all the warehouse destination docs.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix
