### PR TITLE
iOS SDK Advertising ID documentation update

### DIFF
--- a/docs/destinations/webhooks.mdx
+++ b/docs/destinations/webhooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Webhooks"
 description: >-
-  Step-by-step guide to send your event data from RudderStack to your configured
+  Step-by-step guide on sending event data from RudderStack to your configured
   webhook endpoint.
 ---
 
@@ -9,14 +9,11 @@ Webhooks allow you to send the events generated via the RudderStack SDK to your 
 
 Once webhooks are enabled as a destination in your dashboard, RudderStack forwards the SDK events to your configured webhook endpoint.
 
-<div class="successBlock">
-
-  **Find the open-source transformer code for this destination in our <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/webhook">GitHub repo</a>.**
+<div class="infoBlock">
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/webhook">GitHub repository</a>.
 </div>
 
-## Getting Started
-
-In order to collect your events at the webhook endpoint, you will first need to add it as a destination to the source from which you are sending event data. Once the destination is enabled, events from [**RudderStack**](https://github.com/rudderlabs/rudder-server) will start to flow to the webhook endpoint.
+## Getting started
 
 Before configuring your source and destination on the [**RudderStack dashboard**](https://app.rudderstack.com/), verify if the platform you are working on is supported by the webhook destination by referring to the table below:
 
@@ -26,15 +23,13 @@ Before configuring your source and destination on the [**RudderStack dashboard**
 | **Cloud mode**      | **Supported** | **Supported** | **Supported** |
 
 <div class="infoBlock">
-
-To know more about the difference between Cloud mode and Device mode in RudderStack, read the <a href="https://rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/">RudderStack connection modes</a> guide.
-
+To know more about the difference between cloud mode and device mode in RudderStack, refer to the <a href="https://rudderstack.com/docs/rudderstack-cloud/rudderstack-connection-modes/">RudderStack Connection Modes</a> guide.
 </div>
 
 Once you have confirmed that your platform supports sending events to webhooks, perform the steps below:
 
-- Choose a source to which you would like to add your webhook endpoint as a destination.
-- Select the destination as **Webhook** to your source. Give your destination a name and then click on **Next**.
+1. Choose a source to which you would like to add your webhook endpoint as a destination.
+2. Select the destination as **Webhook** to your source. Give your destination a name and then click on **Next**.
 - Next, in the **Connection Settings** page, enter the relevant connection information and click on **Next**
 
 <img src="../assets/screenshot-2020-08-24-at-10.24.37-am.png" />
@@ -51,15 +46,11 @@ The settings are:
 | `Content-Type` | `application/json` |
 
 <div class="infoBlock">
-
-RudderStack also supports adding a dynamic header for your events through user transformation. For more information, refer to our <a href="https://github.com/rudderlabs/sample-user-transformers/blob/master/AddDynamicHeader.js">user transformer code</a> in our GitHub repo.
-
+RudderStack also supports adding a dynamic header for your events through user transformation. For more information, refer to our <a href="https://github.com/rudderlabs/sample-user-transformers#dynamic-header">user transformer code</a> in our GitHub repo.
 </div>
 
 <div class="infoBlock">
-
-You can also add a dynamic path to your base URL. For more information on how to do this, refer to our <a href="https://github.com/rudderlabs/sample-user-transformers/blob/master/DynamicPathtoBaseURL.js">user transformer code</a> in our GitHub repo.
-
+You can also add a dynamic path to your base URL. For more information on how to do this, refer to our <a href="https://github.com/rudderlabs/sample-user-transformers#dynamic-path">user transformer code</a> in our GitHub repo.
 </div>
 
 ## Identify
@@ -116,7 +107,7 @@ For each `identify` call, RudderStack sends the request in the following manner 
 
 ## Page
 
-The `page` call lets you record your website's page views, with any additional relevant information about the viewed page. For more information on the `page` call, refer to the [**RudderStack API Specification**](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/) guide.
+The `page` call lets you record your website's page views, with any additional relevant information about the viewed page. For more information on the `page` call, refer to the [RudderStack API Specification](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/) guide.
 
 A sample `page` payload is as shown:
 
@@ -170,7 +161,7 @@ For each `page` call, RudderStack sends the request in the following manner\(dep
 
 ## Track
 
-The `track` call captures all the activities that the user performs, along with any other properties that are associated with those activities. Each of these activities or actions is considered as an **event**. For more information on the `track` call, refer to the [**RudderStack API Specification**](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/) guide.
+The `track` call captures all the activities that the user performs, along with any other properties that are associated with those activities. Each of these activities or actions is considered as an **event**. For more information on the `track` call, refer to the [RudderStack API Specification](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/) guide.
 
 A sample `track` payload is as shown:
 
@@ -222,7 +213,7 @@ A sample `track` payload is as shown:
 }
 ```
 
-To view the other events and detailed event structure for the types of events being sent, check out the [**RudderStack API Specification**](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/).
+To view the other events and detailed event structure for the types of events being sent, check out the [RudderStack API Specification](https://rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-spec/).
 
 For each `track` call, RudderStack sends the request in the following manner\(depending on the URL method configured in the dashboard\):
 
@@ -230,9 +221,7 @@ For each `track` call, RudderStack sends the request in the following manner\(de
 - **`PUT`:** RudderStack sends the whole event payload \(as shown above\) as the JSON body of the `PUT` request.
 - **`GET`:** RudderStack sends the properties that you pass in the `track` call as query parameters of the `GET` request. If your properties contain nested values, RudderStack will flatten these values before sending them.
 
-## Features
-
-### Dynamic Header Support
+## Dynamic header support
 
 In the settings config, you can set static headers for the webhook call. However, in some cases you may want to dynamically change or add a header to the webhook. This can be done through a top-level object with a key of `header`. This top-level key can be added using a [user transformation](https://rudderstack.com/docs/transformations/) and the following line of code `event.header = { "Authorization": "some-auth" }`. Below is an example of a payload with this feature.
 
@@ -251,7 +240,7 @@ In the settings config, you can set static headers for the webhook call. However
 }
 ```
 
-### Dynamically Append to Endpoint URL
+### Dynamically appending to endpoint URL
 
 In the settings config, you will enter the endpoint that this webhook will be pointed to. There are some use-cases where depending on the event that is going to this destination, the endpoint may need to be changed. RudderStack allows you to append a dynamic string to your webhook endpoint using a top-level key named `appendPath`. This top-level key can be added using a [user transformation](https://rudderstack.com/docs/transformations/) and the following line of code `event.appendPath = 'some-path'`.
 
@@ -269,20 +258,19 @@ Final Endpoint
 endpoint: 'https://www.google.com/search?q=cats'
 ```
 
-## FAQs
+## FAQ
 
-### How to check if there are any delivery failures for the events sent to the webhook?
+### How do I check for any event delivery failures?
 
-- Login to your account in [**RudderStack app**](https://app.rudderstack.com).
-- Verify that you are sending the events in the **Live Events** tab of your source.
-- Check if there are any delivery failures in the **Live Events** tab of your destination. An example of an event failure is as shown:
+1. Log into your [RudderStack dashboard](https://app.rudderstack.com).
+2. Verify that you are sending the events in the **Live Events** tab of your source.
+3. Check if there are any delivery failures in the **Live Events** tab of your destination. An example of an event failure is as shown:
 
-<img src="https://user-images.githubusercontent.com/59817155/125619804-64033117-16f6-44c7-8050-286059ab404d.png" /><span class="imageTitle">Failed Event</span>
+<img src="https://user-images.githubusercontent.com/59817155/125619804-64033117-16f6-44c7-8050-286059ab404d.png" />
+4. You can then check the **Error Response** to get more details about the error, including the reason of the failure, as shown:
 
-- You can then check the **Error Response** to get more details about the error, including the reason of the failure, as shown:
+<img src="https://user-images.githubusercontent.com/59817155/125619922-c68b1c48-50aa-4ce9-8803-8381170e3cc9.png" />
 
-<img src="https://user-images.githubusercontent.com/59817155/125619922-c68b1c48-50aa-4ce9-8803-8381170e3cc9.png" /><span class="imageTitle">Error Response</span>
+## Contact us
 
-## Contact Us
-
-If you come across any issues while configuring webhooks with RudderStack, please feel free to [**contact us**](mailto:%20docs@rudderstack.com). You can also start a conversation in our [**Slack**](https://rudderstack.com/join-rudderstack-slack-community) community; we will be happy to talk to you!
+If you come across any issues while configuring webhooks with RudderStack, please feel free to [contact us](mailto:%20docs@rudderstack.com). You can also start a conversation in our [Slack](https://rudderstack.com/join-rudderstack-slack-community) community; we will be happy to talk to you!

--- a/docs/destinations/webhooks.mdx
+++ b/docs/destinations/webhooks.mdx
@@ -240,7 +240,7 @@ In the settings config, you can set static headers for the webhook call. However
 }
 ```
 
-### Dynamically appending to endpoint URL
+## Dynamically appending to endpoint URL
 
 In the settings config, you will enter the endpoint that this webhook will be pointed to. There are some use-cases where depending on the event that is going to this destination, the endpoint may need to be changed. RudderStack allows you to append a dynamic string to your webhook endpoint using a top-level key named `appendPath`. This top-level key can be added using a [user transformation](https://rudderstack.com/docs/transformations/) and the following line of code `event.appendPath = 'some-path'`.
 
@@ -263,7 +263,7 @@ endpoint: 'https://www.google.com/search?q=cats'
 ### How do I check for any event delivery failures?
 
 1. Log into your [RudderStack dashboard](https://app.rudderstack.com).
-2. Verify that you are sending the events in the **Live Events** tab of your source.
+2. Verify if your events are sent using the **Live Events** tab of your source.
 3. Check if there are any delivery failures in the **Live Events** tab of your destination. An example of an event failure is as shown:
 
 <img src="https://user-images.githubusercontent.com/59817155/125619804-64033117-16f6-44c7-8050-286059ab404d.png" />

--- a/docs/destinations/webhooks.mdx
+++ b/docs/destinations/webhooks.mdx
@@ -30,7 +30,7 @@ Once you have confirmed that your platform supports sending events to webhooks, 
 
 1. Choose a source to which you would like to add your webhook endpoint as a destination.
 2. Select the destination as **Webhook** to your source. Give your destination a name and then click on **Next**.
-- Next, in the **Connection Settings** page, enter the relevant connection information and click on **Next**
+3. Next, in the **Connection Settings** page, enter the relevant connection information and click on **Continue**.
 
 <img src="../assets/screenshot-2020-08-24-at-10.24.37-am.png" />
 

--- a/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -668,8 +668,8 @@ val rudderClient = RudderClient.getInstance(
         .build()
 )
 ```
-- `com.google.android.gms.ads.identifier.AdvertisingIdClient` is present in your application's class path.
-- `limitAdTracking`is not enabled for your device.
+- The dependency `implementation com.google.android.gms:play-services-ads-identifier: 17.0.1` is added to your application's `build.gradle` file.
+- `limitAdTracking` is not enabled for your device.
 
 To set your own advertisement ID, you can use the `putAdvertisingId` method, as shown:
 

--- a/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
+++ b/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-android-sdk/index.mdx
@@ -668,7 +668,12 @@ val rudderClient = RudderClient.getInstance(
         .build()
 )
 ```
-- The dependency `implementation com.google.android.gms:play-services-ads-identifier: 17.0.1` is added to your application's `build.gradle` file.
+- The dependency `com.google.android.gms:play-services-ads-identifier: 17.0.1` is added to your application's `build.gradle` file. To do so, add the following line in your `build.gradle`:
+
+```groovy
+implementation com.google.android.gms:play-services-ads-identifier: 17.0.1
+```
+
 - `limitAdTracking` is not enabled for your device.
 
 To set your own advertisement ID, you can use the `putAdvertisingId` method, as shown:

--- a/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/index.mdx
+++ b/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/index.mdx
@@ -570,9 +570,18 @@ Follow the instructions below:
 
 ## Advertisement ID
 
-We have kept IDFA collection completely separate from the Core library so that the developer has better control over the same. You can pass the IDFA to `putAdvertisementId` method to set it under `context.device.advertisingId`
+We have kept IDFA collection completely separate from the Core library so that the developer has better control over the same. You can pass the IDFA to `putAdvertisementId` method to set it under `context.device.advertisingId`.
+
+<div class="warningBlock">
+From <strong>iOS 14</strong>, you need to request authorization to access the app-related data for tracking the user or the device using the <code class="inline-code">AppTrackingTransparency</code> framework.
+</div>
 
 Follow the instructions below:
+
+1. Set up [`NSUserTrackingUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription) to display the necessary permissions alert request for your app installed on the user device.
+2. Call [`requestTrackingAuthorization(completionHandler:)`](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorization) to present the required authorization request to the user.
+3. Use the [`trackingAuthorizationStatus`](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547038-trackingauthorizationstatus) method to determine the permission status related to the app tracking.
+4. Then, use the `AdSupport` framework to retrieve an instance of the `ASIdentifierManager`, as shown:
 
 ```objectivec
 #import <AdSupport/ASIdentifierManager.h>
@@ -593,6 +602,12 @@ Follow the instructions below:
     return [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
 }
 ```
+
+5. You can use the `advertisingIdentifier` property obtained above to retrieve the UUID.
+
+<div class="infoBlock">
+For more information on getting the advertising identifier, refer to the <a href="https://developer.apple.com/documentation/adsupport">Apple documentation</a>.
+</div>
 
 ## ATTrackingManager authorization consent
 

--- a/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/index.mdx
+++ b/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/index.mdx
@@ -570,7 +570,7 @@ Follow the instructions below:
 
 ## Advertisement ID
 
-We have kept IDFA collection completely separate from the Core library so that the developer has better control over the same. You can pass the IDFA to `putAdvertisementId` method to set it under `context.device.advertisingId`.
+The IDFA collection is kept separately from the Core library so that the developer has better control over the same. You can pass the IDFA to `putAdvertisementId` method to set it under `context.device.advertisingId`.
 
 <div class="warningBlock">
 From <strong>iOS 14</strong>, you need to request authorization to access the app-related data for tracking the user or the device using the <code class="inline-code">AppTrackingTransparency</code> framework.


### PR DESCRIPTION
## Description of the change

> Updated steps for obtaining the advertising ID for iOS 14.
> Fixed 2 URLs in the webhook destination doc

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [x] Hotfix

## Notion ticket link

> [iOS SDK AdvertisingID Documentation Update](https://www.notion.so/rudderstacks/iOS-SDK-AdvertisingID-Documentation-Update-3468781d00604a10b43b76a3a0b0dc29)
> [Broken URLs in Webhook destination](https://www.notion.so/rudderstacks/Broken-URLs-in-Webhook-destination-3956e365ede74f59a89f90c55b530218)
