### PR TITLE
Remove rate limit note for GA destinations

### DIFF
--- a/docs/destinations/streaming-destinations/google-adwords-enhanced-conversions.mdx
+++ b/docs/destinations/streaming-destinations/google-adwords-enhanced-conversions.mdx
@@ -7,10 +7,6 @@ description: Step-by-step guide on sending your event data from RudderStack to G
 
 RudderStack supports Google Adwords Enhanced Conversions as a destination to which you can send your audience list.
 
-<div class="dangerBlock">
-This destination is <strong>temporarily</strong> rate-limited and there is a possibility your events might not flow through. The RudderStack team is actively working on a fix for this issue. For any questions, <a href="mailto:%20support@rudderstack.com">contact us</a> or start a conversation in our <a href="https://rudderstack.com/join-rudderstack-slack-community">Slack</a> community.
-</div>
-
 <div class="infoBlock">
 To use this destination, you must set up Enhanced Conversions with the Google Ads API. For detailed instructions, refer to the <a href="https://support.google.com/google-ads/answer/11062876" target="_blank">Google Ads support page</a>.
 </div>

--- a/docs/destinations/streaming-destinations/google-adwords-remarketing-list.mdx
+++ b/docs/destinations/streaming-destinations/google-adwords-remarketing-list.mdx
@@ -7,10 +7,6 @@ description: Step-by-step guide on sending your event data from RudderStack to G
 
 RudderStack supports Google Adwords Remarketing Lists as a destination to which you can send your audience list.
 
-<div class="dangerBlock">
-This destination is <strong>temporarily</strong> rate-limited and there is a possibility your events might not flow through. The RudderStack team is actively working on a fix for this issue. For any questions, <a href="mailto:%20support@rudderstack.com">contact us</a> or start a conversation in our <a href="https://rudderstack.com/join-rudderstack-slack-community">Slack</a> community.
-</div>
-
 ## Getting started
 
 Before configuring Google Adwords Remarketing Lists as a destination in RudderStack, verify if the source platform is supported by referring to the table below:


### PR DESCRIPTION
## Description of the change

> Removed rate limit note for 2 destinations:
- GA Remarketing Lists
- GA Enhanced Conversions

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix

## Notion ticket link

> [Remove rate limit note](https://www.notion.so/rudderstacks/Remove-rate-limit-note-for-GARL-and-GA-Enhanced-Conversions-edeca820c52e44d9b97843cabf189f41)