### PR TITLE
Tracking Plans definition update

### DIFF
--- a/docs/dashboard-guides/overview.mdx
+++ b/docs/dashboard-guides/overview.mdx
@@ -101,7 +101,7 @@ Refer to the <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> guide fo
 
 ## Tracking Plans
 
-**Tracking Plans** is a **pro/enterprise feature** that lets you proactively monitor and act on non-compliant event data coming into your RudderStack sources based on the predefined plans. It ensures data quality and validates your expected events against the live events that are delivered to RudderStack with real-time validation.
+RudderStack's **Tracking Plans** feature lets you you proactively monitor and act on non-compliant event data coming into your RudderStack sources based on the predefined plans. It ensures data quality by validating the live events delivered to RudderStack against the expected events.
 
 <div class="infoBlock">
 Refer to the <Link to="/features/data-governance/tracking-plans/">Tracking plans</Link> guide for more information on creating and using tracking plans in RudderStack.


### PR DESCRIPTION
## Description of the change

> Updated the definition for the tracking plans in the dashboard overview guide.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix