### PR TITLE
Dynamic destination config guide updates

### DIFF
--- a/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
+++ b/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
@@ -21,7 +21,7 @@ To use this feature, enter the path of the payload along with a default value in
 The format in which the setting should be specified is shown below:
 
 ```javascript
-{{event.path.config.name || "default_config_value"}}
+{{message.path.config.name || "default_config_value"}}
 ```
 
 You can also use this feature to dynamically configure complex input types like field mappings, as seen in the following example:
@@ -54,21 +54,21 @@ Suppose you want to send your event data to different Google Analytics instances
 To populate the configuration values from the event payload, you need to <Link to="/features/transformations/#adding-a-transformation">add a transformation function</Link>. A sample function is shown below:
 
 ```javascript
-export function transformEvent(event, metadata) {
-  let updatedEvent = event;
-  const met = metadata(event);
+export function transformEvent(message, metadata) {
+  let updatedEvent = message;
+  const met = metadata(message);
   if (
     met &&
     met.sourceId === "example_source_id_1" &&
-    event &&
-    event.properties
+    message &&
+    message.properties
   ) {
     updatedEvent.properties.trackingId = "UA-Custom-TrackingID_1";
   } else if (
     met &&
     met.sourceId === "example_source_id_2" &&
-    event &&
-    event.properties
+    message &&
+    message.properties
   ) {
     updatedEvent.properties.trackingId = "UA-Custom-TrackingID_2";
   }
@@ -224,7 +224,7 @@ This feature is very useful if you want to configure multiple instances of the s
 In the text field of a particular connection setting that you want to configure, enter the path of the payload along with a default value in the following format:
 
 ```javascript
-{{ event.path.config.name || "default_config_value" }}
+{{ message.path.config.name || "default_config_value" }}
 ```
 
 If you don't want to use this feature, you can enter the configuration setting in the dashboard as you normally would.

--- a/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
+++ b/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
@@ -54,21 +54,21 @@ Suppose you want to send your event data to different Google Analytics instances
 To populate the configuration values from the event payload, you need to <Link to="/features/transformations/#adding-a-transformation">add a transformation function</Link>. A sample function is shown below:
 
 ```javascript
-export function transformEvent(message, metadata) {
-  let updatedEvent = message;
-  const met = metadata(message);
+export function transformEvent(event, metadata) {
+  let updatedEvent = event;
+  const met = metadata(event);
   if (
     met &&
     met.sourceId === "example_source_id_1" &&
-    message &&
-    message.properties
+    event &&
+    event.properties
   ) {
     updatedEvent.properties.trackingId = "UA-Custom-TrackingID_1";
   } else if (
     met &&
     met.sourceId === "example_source_id_2" &&
-    message &&
-    message.properties
+    event &&
+    event.properties
   ) {
     updatedEvent.properties.trackingId = "UA-Custom-TrackingID_2";
   }

--- a/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
+++ b/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
@@ -229,10 +229,6 @@ In the text field of a particular connection setting that you want to configure,
 
 If you don't want to use this feature, you can enter the configuration setting in the dashboard as you normally would.
 
-### Can I use this feature to dynamically configure a warehouse destination?
-
-Yes, you can. Make sure that the warehouse credentials that you use to configure the destination are applicable for the dynamic project ID/database/any other configuration values from the event payload.
-
 ### Can I specify only the payload path without a default value?
 
 We highly recommend setting a payload path along with a default value. This is because if, for some reason, the payload path does not have any value, the default value is passed as the connection setting. If both the values are absent, you will get an error. 

--- a/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
+++ b/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
@@ -60,15 +60,15 @@ export function transformEvent(event, metadata) {
   if (
     met &&
     met.sourceId === "example_source_id_1" &&
-    event.message &&
-    event.message.properties
+    event &&
+    event.properties
   ) {
     updatedEvent.properties.trackingId = "UA-Custom-TrackingID_1";
   } else if (
     met &&
     met.sourceId === "example_source_id_2" &&
-    event.message &&
-    event.message.properties
+    event &&
+    event.properties
   ) {
     updatedEvent.properties.trackingId = "UA-Custom-TrackingID_2";
   }

--- a/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
+++ b/docs/user-guides/how-to-guides/dynamic-destination-configuration.mdx
@@ -11,7 +11,7 @@ Simply pass the path of your event payload from which the configuration value wi
 <img src="../../assets/user-guides/dynamic-destination-configuration.png" />
 
 <div class="successBlock">
-This feature is supported for all the destinations that support sending data via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>, including <Link to="/destinations/warehouse-destinations/">warehouse destinations</Link>.
+This feature is supported for all the destinations that support sending data via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 </div>
 
 ## Supported format


### PR DESCRIPTION
If I understood the request correctly, this PR removes the extraneous `message` objects from the example code. 

Additionally, we can clarify this page by replacing the instances of `message` with `event` once 
https://github.com/rudderlabs/rudder-transformer/pull/1289 is in production, as this usage can cause confusion for docs users.
