### PR TITLE
Fix typo in code block example

### DIFF
--- a/docs/destinations/streaming-destinations/launchdarkly.mdx
+++ b/docs/destinations/streaming-destinations/launchdarkly.mdx
@@ -62,7 +62,7 @@ rudderanalytics.identify(
     ip: "12.23.34.45",
     lastName: "Keener",
     name: "Alex Keener",
-    privateAttribureNames: ["avatar", "country"],
+    privateAttributeNames: ["avatar", "country"],
     secondary: "abcd21234"
   }
 );


### PR DESCRIPTION
## What do these changes do?

Fixes typo in code block example. `privateAttributeNames` was misspelled.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [X] Hotfix

## Notion ticket link

N/A
