### PR TITLE
Remove trailing slash from urls

### DIFF
--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -2,12 +2,12 @@
 title: "RudderStack API"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/api/http-api/');
+    navigate("/api/http-api");
   }, []);
   return null;
 };

--- a/docs/dashboard-guides/index.mdx
+++ b/docs/dashboard-guides/index.mdx
@@ -2,12 +2,12 @@
 title: "Dashboard Guides"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/dashboard-guides/overview/');
+    navigate("/dashboard-guides/overview");
   }, []);
   return null;
 };

--- a/docs/destinations/index.mdx
+++ b/docs/destinations/index.mdx
@@ -2,12 +2,12 @@
 title: "Destinations"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/destinations/overview/');
+    navigate("/destinations/overview");
   }, []);
   return null;
 };

--- a/docs/event-spec/index.mdx
+++ b/docs/event-spec/index.mdx
@@ -2,12 +2,12 @@
 title: "Event Specification"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/event-spec/standard-events/');
+    navigate("/event-spec/standard-events");
   }, []);
   return null;
 };

--- a/docs/features/index.mdx
+++ b/docs/features/index.mdx
@@ -2,12 +2,12 @@
 title: "Features"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/features/transformations/');
+    navigate("/features/transformations");
   }, []);
   return null;
 };

--- a/docs/get-started/index.mdx
+++ b/docs/get-started/index.mdx
@@ -2,12 +2,12 @@
 title: "Get Started"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/get-started/what-is-rudderstack/');
+    navigate("/get-started/what-is-rudderstack");
   }, []);
   return null;
 };

--- a/docs/resources/index.mdx
+++ b/docs/resources/index.mdx
@@ -2,12 +2,12 @@
 title: "Resources"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/resources/rudderstack-architecture/');
+    navigate("/resources/rudderstack-architecture");
   }, []);
   return null;
 };

--- a/docs/sources/reverse-etl/common-settings/index.mdx
+++ b/docs/sources/reverse-etl/common-settings/index.mdx
@@ -2,12 +2,12 @@
 title: "Common Settings"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/sources/reverse-etl/common-settings/sync-modes/');
+    navigate("/sources/reverse-etl/common-settings/sync-modes");
   }, []);
   return null;
 };

--- a/docs/sources/reverse-etl/features/index.mdx
+++ b/docs/sources/reverse-etl/features/index.mdx
@@ -2,15 +2,12 @@
 title: "Features"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/sources/reverse-etl/features/models/');
+    navigate("/sources/reverse-etl/features/models");
   }, []);
   return null;
 };
-
-
-

--- a/docs/user-guides/index.mdx
+++ b/docs/user-guides/index.mdx
@@ -2,12 +2,12 @@
 title: "User Guides"
 ---
 
-import { useEffect } from 'react';
-import { navigate } from 'gatsby';
+import { useEffect } from "react";
+import { navigate } from "gatsby";
 
 export default () => {
   useEffect(() => {
-    navigate('/user-guides/migration-guides/');
+    navigate("/user-guides/migration-guides");
   }, []);
   return null;
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -141,7 +141,9 @@ module.exports = {
           }
         `,
         resolvePages: ({ allMdx: { nodes: allMdxPages } }) => {
-          return allMdxPages.map((page) => ({ path: `/${page.slug}` }));
+          return allMdxPages.map((page) => {
+            return { path: `/${page.slug.replace(/\/$/, "")}` };
+          });
         },
         serialize: ({ path }) => ({
           url: path,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,36 +1,37 @@
-require('dotenv').config({
-  path: `.env.${process.env.NODE_ENV}`,
-})
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`
+});
 
 module.exports = {
+  trailingSlash: "never",
   pathPrefix: `/docs`,
   flags: {
     FAST_DEV: true,
     DEV_SSR: true,
-    PRESERVE_FILE_DOWNLOAD_CACHE: true,
+    PRESERVE_FILE_DOWNLOAD_CACHE: true
   },
   siteMetadata: {
     title: `Rudderstack`,
     description: `RudderStack is the easiest way to stream data from your website or warehouse. With RudderStack, you can easily collect customer data from every platform.`,
     author: `@Rudderstack`,
-    siteUrl: 'https://www.rudderstack.com',
-    siteTitle: 'RudderStack',
-    defaultTitle: 'RudderStack Docs',
-    siteTitleShort: 'RudderStack',
-    siteAuthor: 'RudderStack',
+    siteUrl: "https://www.rudderstack.com",
+    siteTitle: "RudderStack",
+    defaultTitle: "RudderStack Docs",
+    siteTitleShort: "RudderStack",
+    siteAuthor: "RudderStack"
   },
   plugins: [
     `gatsby-plugin-postcss`,
     {
-      resolve: 'gatsby-plugin-preconnect',
+      resolve: "gatsby-plugin-preconnect",
       options: {
-        domains: ['https://rudderstack.com', 'https://localhost:8000'],
-      },
+        domains: ["https://rudderstack.com", "https://localhost:8000"]
+      }
     },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `./src/data/`,
+        path: `./src/data/`
       }
     },
     {
@@ -38,8 +39,8 @@ module.exports = {
       options: {
         printRejected: true, // Print removed selectors and processed file names
         develop: true, // Enable while using `gatsby develop`
-        tailwind: true, // Enable tailwindcss support
-      },
+        tailwind: true // Enable tailwindcss support
+      }
     },
     `gatsby-plugin-image`,
     `gatsby-transformer-sharp`,
@@ -48,9 +49,9 @@ module.exports = {
       resolve: `gatsby-plugin-sharp`,
       options: {
         defaults: {
-          formats: [`auto`, `webp`],
-        },
-      },
+          formats: [`auto`, `webp`]
+        }
+      }
     },
     {
       resolve: `gatsby-source-sanity`,
@@ -58,37 +59,37 @@ module.exports = {
         projectId: process.env.GATSBY_SANITY_PROJECTID,
         dataset: process.env.GATSBY_SANITY_DATASET,
         token: process.env.GATSBY_SANITY_TOKEN,
-        graphqlTag: 'default',
-      },
+        graphqlTag: "default"
+      }
     },
     {
       resolve: `gatsby-plugin-rudderstack`,
       options: {
         prodKey: process.env.RS_PRODUCTION_WRITE_KEY,
-        loadType: 'defer',
+        loadType: "defer",
         trackPage: false,
         loadAsync: true,
         delayLoad: true,
         delayLoadTime: 1000,
         useNewSDK: true,
-        sdkURL: 'https://cdn.rudderlabs.com/v1.1/beta/rudder-analytics.min.js',
-        dataPlaneUrl: `https://rudderstack-dataplane.rudderstack.com`,
-      },
+        sdkURL: "https://cdn.rudderlabs.com/v1.1/beta/rudder-analytics.min.js",
+        dataPlaneUrl: `https://rudderstack-dataplane.rudderstack.com`
+      }
     },
     `gatsby-transformer-csv`,
-    'gatsby-plugin-use-query-params',
+    "gatsby-plugin-use-query-params",
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-plugin-react-helmet-canonical-urls`,
       options: {
-        siteUrl: process.env.RS_SITE_URL,
-      },
+        siteUrl: process.env.RS_SITE_URL
+      }
     },
     {
-      resolve: '@rocketseat/gatsby-theme-docs',
+      resolve: "@rocketseat/gatsby-theme-docs",
       options: {
-        withMdx: false,
-      },
+        withMdx: false
+      }
     },
     {
       resolve: `gatsby-plugin-mdx`,
@@ -98,8 +99,8 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              elements: [`h2`, `h3`, `h4`],
-            },
+              elements: [`h2`, `h3`, `h4`]
+            }
           },
           `gatsby-remark-embedder`,
           {
@@ -109,27 +110,27 @@ module.exports = {
               withWebp: false,
               linkImagesToOriginal: false,
               srcSetBreakpoints: [960],
-              breakpoints: [960],
-            },
+              breakpoints: [960]
+            }
           },
           `gatsby-remark-responsive-iframe`,
-          `gatsby-remark-copy-linked-files`,
+          `gatsby-remark-copy-linked-files`
         ],
-        plugins: [`gatsby-remark-autolink-headers`, `gatsby-remark-images`],
-      },
+        plugins: [`gatsby-remark-autolink-headers`, `gatsby-remark-images`]
+      }
     },
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
         icon: `src/images/favicon.png`,
-        icons: [],
-      },
+        icons: []
+      }
     },
     {
       resolve: `gatsby-plugin-sitemap`,
       options: {
         output: `/sitemaps`,
-        resolveSiteUrl: () => 'https://www.rudderstack.com',
+        resolveSiteUrl: () => "https://www.rudderstack.com",
         query: `
           {
             allMdx {
@@ -140,37 +141,37 @@ module.exports = {
           }
         `,
         resolvePages: ({ allMdx: { nodes: allMdxPages } }) => {
-          return allMdxPages.map(page => ({ path: `/${page.slug}` }))
+          return allMdxPages.map((page) => ({ path: `/${page.slug}` }));
         },
         serialize: ({ path }) => ({
           url: path,
-          changefreq: 'daily',
+          changefreq: "daily",
           priority: 0.7
         })
       }
     },
     ...(process.env.RS_GATSBY_ALGOLIA_APIKEY
       ? [
-        {
-          resolve: `gatsby-plugin-algolia`,
-          options: {
-            appId: process.env.GATSBY_ALGOLIA_APP_ID,
-            apiKey: process.env.RS_GATSBY_ALGOLIA_APIKEY,
-            indexName:
-              process.env.GATSBY_ALGOLIA_INDEX_PREFIX + "_gatsby_docs_v2",
-            queries: require("./src/utils/docs-algolia"),
-            enablePartialUpdates: true,
-            matchFields: [
-              "objectID",
-              "title",
-              "aliases",
-              "slug",
-              "headings",
-              "excerpt"
-            ],
-          },
-        },
-      ]
-      : []),
-  ],
-}
+          {
+            resolve: `gatsby-plugin-algolia`,
+            options: {
+              appId: process.env.GATSBY_ALGOLIA_APP_ID,
+              apiKey: process.env.RS_GATSBY_ALGOLIA_APIKEY,
+              indexName:
+                process.env.GATSBY_ALGOLIA_INDEX_PREFIX + "_gatsby_docs_v2",
+              queries: require("./src/utils/docs-algolia"),
+              enablePartialUpdates: true,
+              matchFields: [
+                "objectID",
+                "title",
+                "aliases",
+                "slug",
+                "headings",
+                "excerpt"
+              ]
+            }
+          }
+        ]
+      : [])
+  ]
+};


### PR DESCRIPTION
## What do these changes do?

Standardizes our url format to exclude trailing slashes. This consistency will help with our SEO efforts.

- Removes trailing slash from sitemap and redirect urls.
- Configures Gatsby to no longer append trailing slashes.