### PR TITLE
Open Source multiple nodes warning

### DIFF
--- a/docs/get-started/rudderstack-open-source/data-plane-setup/index.mdx
+++ b/docs/get-started/rudderstack-open-source/data-plane-setup/index.mdx
@@ -20,8 +20,12 @@ Based on the platform where you want to set up RudderStack, refer to the setup i
 
 * <Link to="/get-started/rudderstack-open-source/data-plane-setup/developer-machine-setup/">Developer Machine Setup</Link>
 
-<div class="warningBlock">
+<div class="infoBlock">
 If you are planning to use RudderStack in production, it is strongly recommended to use the <a href="kubernetes/">Kubernetes</a> Helm charts. The Docker images are updated with the latest bug fixes more frequently than the <a href="https://github.com/rudderlabs/rudder-server">GitHub repository</a>.
+</div>
+
+<div class="dangerBlock">
+In RudderStack Open Source, every node runs the warehouse sync operations individually. Setting up multiple nodes can cause concurrent requests to your warehouse, leading to failures and retries. It can also increase your costs in the case of data warehouses like Snowflake, BigQuery, etc.
 </div>
 
 ## Sending test events


### PR DESCRIPTION
## What do these changes do?

> Added warning note re: deploying multiple RudderStack nodes for running multiple warehouse services.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
