### PR TITLE
HubSpot doc update for RETL sources

### DIFF
--- a/docs/destinations/streaming-destinations/hubspot-v2.mdx
+++ b/docs/destinations/streaming-destinations/hubspot-v2.mdx
@@ -11,7 +11,6 @@ RudderStack supports HubSpot as a destination where you can seamlessly send your
 Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/hs">GitHub repository</a>.
 </div>
 
-
 ## Getting started
 
 Before configuring HubSpot as a destination in RudderStack, verify if the source platform is supported by HubSpot by referring to the table below:
@@ -178,6 +177,42 @@ The following table lists the **optional** and default property mappings between
 | `context.device.name`            | `hs_device_name`            |          
 | `properties.elementClass`/`properties.hsElementClass`               | `hs_element_class`               |             
 | `properties.elementId`/`properties.hsElementId`              | `hs_element_id`              |    
+
+## Connecting Reverse ETL sources
+
+If you're connecting a <Link to="/sources/reverse-etl/">Reverse ETL</Link> source to your HubSpot destination that uses a <a href="https://developers.hubspot.com/docs/api/intro-to-auth#private-app-access-tokens">private app access token</a> for authentication, make sure your access token has the following scopes:
+
+```
+crm.lists.read
+crm.objects.contacts.read
+crm.objects.contacts.write
+crm.schemas.custom.read
+crm.objects.custom.read
+crm.objects.custom.write
+crm.schemas.custom.write
+crm.objects.companies.write
+crm.schemas.contacts.read
+crm.lists.write
+crm.objects.companies.read
+crm.objects.deals.read
+crm.objects.deals.write
+crm.schemas.companies.read
+crm.schemas.companies.write
+crm.schemas.contacts.write
+crm.schemas.deals.read
+crm.schemas.deals.write
+crm.objects.owners.read
+crm.objects.quotes.write
+crm.objects.quotes.read
+crm.schemas.quotes.read
+crm.objects.line_items.read
+crm.objects.line_items.write
+crm.schemas.line_items.read
+```
+
+<div class="infoBlock">
+For more information on adding the above scopes, refer to the <a href="https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app#create-a-new-private-app">HubSpot documentation</a>.
+</div>
 
 ## FAQ
 

--- a/docs/destinations/streaming-destinations/hubspot.mdx
+++ b/docs/destinations/streaming-destinations/hubspot.mdx
@@ -219,6 +219,42 @@ A sample `screen` call sent via the iOS SDK is shown below:
             properties:@{@"prop_key" : @"prop_value"}];
 ```
 
+## Connecting Reverse ETL sources
+
+If you're connecting a <Link to="/sources/reverse-etl/">Reverse ETL</Link> source to your HubSpot destination that uses a <a href="https://developers.hubspot.com/docs/api/intro-to-auth#private-app-access-tokens">private app access token</a> for authentication, make sure your access token has the following scopes:
+
+```
+crm.lists.read
+crm.objects.contacts.read
+crm.objects.contacts.write
+crm.schemas.custom.read
+crm.objects.custom.read
+crm.objects.custom.write
+crm.schemas.custom.write
+crm.objects.companies.write
+crm.schemas.contacts.read
+crm.lists.write
+crm.objects.companies.read
+crm.objects.deals.read
+crm.objects.deals.write
+crm.schemas.companies.read
+crm.schemas.companies.write
+crm.schemas.contacts.write
+crm.schemas.deals.read
+crm.schemas.deals.write
+crm.objects.owners.read
+crm.objects.quotes.write
+crm.objects.quotes.read
+crm.schemas.quotes.read
+crm.objects.line_items.read
+crm.objects.line_items.write
+crm.schemas.line_items.read
+```
+
+<div class="infoBlock">
+For more information on adding the above scopes, refer to the <a href="https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app#create-a-new-private-app">HubSpot documentation</a>.
+</div>
+
 ## FAQ
 
 ### Where do I get the API Key and Hub ID for HubSpot?
@@ -241,5 +277,3 @@ To get the Access Token:
 ### Can I use HubSpot website analytics?
 
 Yes - RudderStack supports sending `page` calls in device mode which can be used for HubSpot website analytics.
-
-

--- a/docs/sources/reverse-etl/faq.mdx
+++ b/docs/sources/reverse-etl/faq.mdx
@@ -73,5 +73,3 @@ For more information, refer to the <a href="https://www.rudderstack.com/docs/sou
 ### I'm unable to run a sync manually and get the message "Your pipeline is paused. Make sure that the source and at least one destination is enabled". What do I do?
 
 This message appears when either your Reverse ETL source, the connected destination, or both are disabled. Go to the **Settings** tab to verify if the source and destination are enabled for data syncs.
-
-


### PR DESCRIPTION
## What do these changes do?

> Updated HubSpot docs specifying the necessary scopes for private apps auth to set up RETL connections.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
