### PR TITLE
fix(destination): typos in branch

### DIFF
--- a/docs/destinations/streaming-destinations/branchio.mdx
+++ b/docs/destinations/streaming-destinations/branchio.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to B
 RudderStack supports sending events from RudderStack SDKs to Branch through our data plane via the S2S \(Server to Server\) connection mode. You can also opt for the device mode as well for Android and iOS. Branch SDK is wrapped inside Rudder SDK in case of device mode.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the<a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/branch">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/branch">GitHub repository</a>.
 </div>
 
 ## Getting started
@@ -40,7 +40,7 @@ Please note that RudderStack does not support sending data to Branch on both dev
 
 ## Adding device mode integration
 
-Depending on the platform of integration follow the steps below to integrate with Device-mode.
+Depending on the platform of integration follow the steps below to integrate with device mode.
 
 <Tabs>
   <TabList>


### PR DESCRIPTION
## What do these changes do?

Fixed some of the typos in the Branch streaming destination docs.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
