### PR TITLE
Split permissions management doc

### DIFF
--- a/docs/dashboard-guides/permissions-management.mdx
+++ b/docs/dashboard-guides/permissions-management.mdx
@@ -3,106 +3,21 @@ title: "Permissions Management"
 description: Detailed description of the permissions management options in RudderStack.
 ---
 
-RudderStack's permissions management feature lets you manage users and their permissions in your RudderStack workspace. 
+RudderStack's permissions management feature gives you the ability to:
 
-This feature allows you to:
-- Easily collaborate between other members of your organization.
 - <Link to="#restricting-edit-permissions-for-individual-objects">Restrict edit permissions</Link> for business-critical objects in your workspace.
-- <Link to="#limiting-access-to-pii-related-features">Limit access</Link> to product features where PII is exposed (for example, Live Events, debug logs, etc.) for compliance purposes.
+- <Link to="#limiting-access-to-pii-related-features">Limit access</Link> to the product features where PII is exposed (for example, Live Events, debug logs, etc.) for compliance purposes.
 
-## Inviting users
-
-To invite a member to your RudderStack workspace, follow these steps:
-1. Go to **Settings** > **Members** and click the **Invite Teammate** button, as shown:
-
-<img src="../assets/rs-cloud/permissions-management-1.png" alt="Invite teammates option" />
-
-2. Enter the member's **Email** and select an appropriate role from the dropdown.
-
-<div class="infoBlock">
-Refer to the <Link to="#role-permissions">Role permissions</Link> section below for more information on the Read-Only, Read-Write, and Admin roles.
-</div>
-
-3. Finally, click **Invite**.
-
-<div class="successBlock">
-Your teammate will be automatically added to the workspace once they accept the invite.
-</div>
-
-## Role permissions
-
-You can assign any of the following three roles to the member you want to invite to your workspace:
-
-- Read-Only
-- Read-Write
-- Admin
-
-The following sections list the **default permissions** associated with each role.
-
-<div class="successBlock">
-You can also set granular access controls and lock down access to specific RudderStack objects and features to a select list of members in your workspace. For more information, refer to the <Link to="#setting-granular-access-controls">Setting granular access controls</Link> section below.
-</div>
-
-### Read-Only
-
-This user role has the following permissions:
-
-| Feature       | View | Add | Modify | Delete |
-| :----------- | :--- | :-- | :----- | :----- |
-| <Link to="/sources/">Sources</Link>   | Yes  | No  | No     | No     |
-| <Link to="/destinations/">Destinations</Link> | Yes  | No  | No     | No     |
-| <Link to="/get-started/quickstart/">Connections</Link>     | Yes  | No  | No     | No     |
-| <Link to="/dashboard-guides/live-events/">Live Events</Link> | Yes | - | - | - |
-| <Link to="/features/transformations/">Transformations</Link> | Yes  | No  | No     | No     |
-| <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> | No | - | - | - |
-| <Link to="/features/data-governance/tracking-plans/">Tracking Plans</Link> | Yes  | No  | No     | No     |
-| <Link to="/sources/reverse-etl/features/models/">Models</Link> | Yes | No  | No     | No     |
-
-Some things to note regarding the read-only user permissions:
-- Read-only users can view the settings of all the destinations. However, secrets like access keys are hidden from them.
-- They can also view any secrets, like API keys in the transformation code.
-
-### Read-Write
-
-A read-write user has all the permissions of a read-only user in addition to modifying the key workspace features and options listed below:
-
-| Feature          | View | Add | Modify | Delete |
-| :-------------- | :--- | :-- | :----- | :----- |
-| <Link to="/sources/">Sources</Link>         | Yes  | Yes | Yes    | Yes    |
-| <Link to="/destinations/">Destinations</Link>    | Yes  | Yes | Yes    | Yes    |
-| <Link to="/get-started/quickstart/">Connections</Link>     | Yes  | Yes | Yes    | Yes    |
-| <Link to="/dashboard-guides/live-events/">Live Events</Link> | Yes | - | - | - |
-| <Link to="/features/transformations/">Transformations</Link> | Yes  | Yes | Yes    | Yes    |
-| <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> | Yes | - | - | - |
-| <Link to="/features/data-governance/tracking-plans/">Tracking Plans</Link> | Yes  | Yes | Yes    | Yes    |
-| <Link to="/sources/reverse-etl/features/models/">Models</Link> | Yes  | Yes | Yes    | Yes    |
-
-### Admin
-
-This user role has complete access to the RudderStack workspace, including all the features in the current plan:
-
-| Feature          | View | Add | Modify | Delete |
-| :------------ | :--- | :-- | :----- | :----- |
-| <Link to="/sources/">Sources</Link>       | Yes  | Yes | Yes    | Yes    |
-| <Link to="/destinations/">Destinations</Link>    | Yes  | Yes | Yes    | Yes    |
-| <Link to="/get-started/quickstart/">Connections</Link>    | Yes  | Yes | Yes    | Yes    |
-| <Link to="/dashboard-guides/live-events/">Live Events</Link> | Yes | - | - | - |
-| <Link to="/features/transformations/">Transformations</Link> | Yes  | Yes | Yes    | Yes    |
-| <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> | Yes | - | - | - |
-| <Link to="/features/data-governance/tracking-plans/">Tracking Plans</Link> | Yes  | Yes | Yes    | Yes    |
-| <Link to="/sources/reverse-etl/features/models/">Models</Link> | Yes  | Yes | Yes    | Yes    |
-
-<div class="infoBlock">
-The Admin role also has some additional permissions related to the configuration of the workspace settings, including managing users, modifying user permissions, enforcing MFA(multi-factor authentication), and more. This role also has the required permissions to <Link to="#setting-granular-access-controls">set granular access controls</Link> for certain business-critical objects and <Link to="#limiting-access-to-pii-related-features">limit PII access</Link> to certain users.
-</div>
+<GhBadge
+  url={'https://rudderstack.com/enterprise-quote'}
+  label={'Plan'}
+  message={'Enterprise'}
+  color={'blueviolet'}
+/>
 
 ## Setting granular access controls
 
-<div class="infoBlock">
-This is an enterprise-only feature.
-</div>
-
-When you add a member to your workspace, RudderStack lets you assign any of the three default global roles - <Link to="#read-only">Read-Only</Link>, <Link to="#read-write">Read-Write</Link>, and <Link to="#admin">Admin</Link>. 
+When you <Link to="/dashboard-guides/user-management/#inviting-users-to-your-workspace">invite a member to your workspace</Link>, RudderStack lets you assign any of the three default global roles to them - <Link to="/dashboard-guides/user-management/#read-only">Read-Only</Link>, <Link to="/dashboard-guides/user-management/#read-write">Read-Write</Link>, and <Link to="/dashboard-guides/user-management/#admin">Admin</Link>.
 
 Although these permissions provide basic controls, they can end up being too broad or too narrow for certain use-cases. For example, admins cannot restrict access to modify a destination's settings without removing edit permissions for the user entirely. 
 
@@ -121,7 +36,7 @@ All the access-related changes are recorded in the <Link to="/dashboard-guides/a
 The **Permissions** tab in the RudderStack dashboard lets you specify the list of members having edit permissions to a given object or resource. 
 
 <div class="infoBlock">
-Only the users with <strong>Admin</strong> role have access to the <strong>Permissions</strong> tab.
+Only users with the <Link to="/dashboard-guides/user-management/#admin">Admin</Link> role have access to the <strong>Permissions</strong> tab.
 </div>
 
 This tab is visible for every source, destination, and model present in the workspace, as seen below:
@@ -135,7 +50,7 @@ The edit permissions include the ability to:
 - Edit or change the resource-specific configuration.
 
 <div class="infoBlock">
-Any action involving setting up a connection between two resources or linking/de-linking a resource with another resource requires edit permissions for both the resources. The only exception is the SQL model which can used without explicitly setting any edit permissions.
+Any action involving setting up a connection between two resources or linking/de-linking a resource with another resource requires edit permissions for both the resources. The only exception is the <Link to="/sources/reverse-etl/features/models/">SQL Models</Link> which can used without explicitly setting any edit permissions.
 </div>
 
 To specify the list of users who can make changes to a given resource, follow these steps:
@@ -154,7 +69,7 @@ To specify the list of users who can make changes to a given resource, follow th
 <img src="../assets/rs-cloud/permissions-management-3.png" alt="Add members option" />
 
 <div class="warningBlock">
-Members with Read-Only permissions cannot be added as they do not have permissions to modify a resource, by default.
+Members with <Link to="/dashboard-guides/user-management/#read-only">Read-Only</Link> permissions cannot be added as they do not have permissions to modify a resource, by default.
 </div>
 
 ### Limiting access to PII-related features
@@ -172,7 +87,7 @@ To set the PII permissions, follow these steps:
 <img src="../assets/rs-cloud/permissions-management-5.png" alt="Data privacy option" />
 
 <div class="infoBlock">
-Only users with the Admin role have access to this tab.
+Only users with the <Link to="/dashboard-guides/user-management/#admin">Admin</Link> role have access to this tab.
 </div>
 
 2. Under **Who can view restricted data?**, select the appropriate option:
@@ -187,5 +102,3 @@ Only users with the Admin role have access to this tab.
 <div class="warningBlock">
 If the admins are removed from the access list, they will be restricted from viewing the PII.
 </div>
-
-

--- a/docs/dashboard-guides/user-management.mdx
+++ b/docs/dashboard-guides/user-management.mdx
@@ -3,7 +3,7 @@ title: "User Management"
 description: Detailed description of the user management options in RudderStack.
 ---
 
-RudderStack's user management feature lets you manage users and their permissions in your RudderStack workspace. It lets you easily collaborate between other members of your organization.
+RudderStack's user management feature lets you manage users and their permissions in your RudderStack workspace. It lets you easily collaborate with other members of your organization.
 
 ## Inviting users to your workspace
 

--- a/docs/dashboard-guides/user-management.mdx
+++ b/docs/dashboard-guides/user-management.mdx
@@ -1,0 +1,93 @@
+---
+title: "User Management"
+description: Detailed description of the user management options in RudderStack.
+---
+
+RudderStack's user management feature lets you manage users and their permissions in your RudderStack workspace. It lets you easily collaborate between other members of your organization.
+
+## Inviting users to your workspace
+
+To invite a member to your RudderStack workspace, follow these steps:
+
+1. Go to **Settings** > **Members** and click the **Invite Teammate** button, as shown:
+
+<img src="../assets/rs-cloud/permissions-management-1.png" alt="Invite teammates option" />
+
+2. Enter the member's **Email** and select an appropriate role from the dropdown.
+
+<div class="infoBlock">
+Refer to the <Link to="#role-permissions">Role permissions</Link> section below for more information on the Read-Only, Read-Write, and Admin roles.
+</div>
+
+3. Finally, click **Invite**.
+
+<div class="successBlock">
+Your teammate will be automatically added to the workspace once they accept the invite.
+</div>
+
+## Role permissions
+
+You can assign any of the following three roles to the member you want to invite to your workspace:
+
+- Read-Only
+- Read-Write
+- Admin
+
+The following sections list the **default permissions** associated with each role.
+
+<div class="successBlock">
+You can also set granular access controls and lock down access to specific RudderStack objects and features to a select list of members in your workspace. For more information, refer to the <Link to="/dashboard-guides/permissions-management/">Permissions Management</Link> guide.
+</div>
+
+### Read-Only
+
+This user role has the following permissions:
+
+| Feature       | View | Add | Modify | Delete |
+| :----------- | :--- | :-- | :----- | :----- |
+| <Link to="/sources/">Sources</Link>   | Yes  | No  | No     | No     |
+| <Link to="/destinations/">Destinations</Link> | Yes  | No  | No     | No     |
+| <Link to="/get-started/quickstart/">Connections</Link>     | Yes  | No  | No     | No     |
+| <Link to="/dashboard-guides/live-events/">Live Events</Link> | Yes | - | - | - |
+| <Link to="/features/transformations/">Transformations</Link> | Yes  | No  | No     | No     |
+| <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> | No | - | - | - |
+| <Link to="/features/data-governance/tracking-plans/">Tracking Plans</Link> | Yes  | No  | No     | No     |
+| <Link to="/sources/reverse-etl/features/models/">Models</Link> | Yes | No  | No     | No     |
+
+The members with read-only user permissions can:
+- View the connection settings for all the destinations. However, they do not have access to view secrets like the access keys.
+- View any secrets in the transformation code like API keys.
+
+### Read-Write
+
+A read-write user has all the permissions of a read-only user in addition to modifying the key workspace features and options listed below:
+
+| Feature          | View | Add | Modify | Delete |
+| :-------------- | :--- | :-- | :----- | :----- |
+| <Link to="/sources/">Sources</Link>         | Yes  | Yes | Yes    | Yes    |
+| <Link to="/destinations/">Destinations</Link>    | Yes  | Yes | Yes    | Yes    |
+| <Link to="/get-started/quickstart/">Connections</Link>     | Yes  | Yes | Yes    | Yes    |
+| <Link to="/dashboard-guides/live-events/">Live Events</Link> | Yes | - | - | - |
+| <Link to="/features/transformations/">Transformations</Link> | Yes  | Yes | Yes    | Yes    |
+| <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> | Yes | - | - | - |
+| <Link to="/features/data-governance/tracking-plans/">Tracking Plans</Link> | Yes  | Yes | Yes    | Yes    |
+| <Link to="/sources/reverse-etl/features/models/">Models</Link> | Yes  | Yes | Yes    | Yes    |
+
+### Admin
+
+This user role has complete access to the RudderStack workspace, including all the features in the current plan:
+
+| Feature          | View | Add | Modify | Delete |
+| :------------ | :--- | :-- | :----- | :----- |
+| <Link to="/sources/">Sources</Link>       | Yes  | Yes | Yes    | Yes    |
+| <Link to="/destinations/">Destinations</Link>    | Yes  | Yes | Yes    | Yes    |
+| <Link to="/get-started/quickstart/">Connections</Link>    | Yes  | Yes | Yes    | Yes    |
+| <Link to="/dashboard-guides/live-events/">Live Events</Link> | Yes | - | - | - |
+| <Link to="/features/transformations/">Transformations</Link> | Yes  | Yes | Yes    | Yes    |
+| <Link to="/dashboard-guides/audit-logs/">Audit Logs</Link> | Yes | - | - | - |
+| <Link to="/features/data-governance/tracking-plans/">Tracking Plans</Link> | Yes  | Yes | Yes    | Yes    |
+| <Link to="/sources/reverse-etl/features/models/">Models</Link> | Yes  | Yes | Yes    | Yes    |
+
+<div class="infoBlock">
+The Admin role also has some additional permissions related to the configuration of the workspace settings, including managing users, modifying user permissions, enforcing MFA(multi-factor authentication), and more. This role also has the required permissions to <Link to="/dashboard-guides/permissions-management/#setting-granular-access-controls">set granular access controls</Link> for certain business-critical objects and <Link to="/dashboard-guides/permissions-management/#limiting-access-to-pii-related-features">limit PII access</Link> to certain users.
+</div>

--- a/src/postNavList.js
+++ b/src/postNavList.js
@@ -1774,6 +1774,12 @@ export const postNavList = [
     content: [],
   },
   {
+    key: "user-management",
+    title: "User Management",
+    link: "/dashboard-guides/user-management/",
+    content: [],
+  },
+  {
     key: "permissions-management",
     title: "Permissions Management",
     link: "/dashboard-guides/permissions-management/",

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -86,6 +86,11 @@ export const jsonData = [
     content: []
 },
 {
+    title: "User Management",
+    link: "/dashboard-guides/user-management/",
+    content: []
+},
+{
     title: "Permissions Management",
     link: "/dashboard-guides/permissions-management/",
     content: []


### PR DESCRIPTION
## What do these changes do?

> Split the permissions management doc into **user management** and **permissions management**.
> Added enterprise label for the permissions management doc

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
