### PR TITLE
Removes beta from the RS SDK cdn url

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -75,7 +75,7 @@ module.exports = {
               delayLoadTime: 1000,
               useNewSDK: true,
               sdkURL:
-                'https://cdn.rudderlabs.com/v1.1/beta/rudder-analytics.min.js',
+                'https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js',
               dataPlaneUrl: `https://rudderstack-dataplane.rudderstack.com`,
             },
           },


### PR DESCRIPTION
## What do these changes do?

> Currently, the CDN url for the RS SDK is 404ing. This removes `/beta`, allowing for the url to resolve.

## Type of documentation

- [x] Hotfix
