### PR TITLE
Add trailingSlash setting to gatsby-config & sitemap entries

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -133,6 +133,12 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-plugin-react-helmet-canonical-urls`,
+      options: {
+        siteUrl: 'https://www.rudderstack.com',
+      },
+    },
+    {
       resolve: `gatsby-plugin-sitemap`,
       options: {
         output: `/sitemaps`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,7 @@ require('dotenv').config({
 })
 
 module.exports = {
+  trailingSlash: 'always',
   pathPrefix: `/docs`,
   flags: {
     FAST_DEV: true,
@@ -149,7 +150,7 @@ module.exports = {
           return allMdxPages.map(page => ({ path: `/${page.slug}` }))
         },
         serialize: ({ path }) => ({
-          url: path,
+          url: `${path}${path.endsWith('/') ? '' : '/'}`,
           changefreq: 'daily',
           priority: 0.7,
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7404,7 +7404,7 @@ gatsby-plugin-purgecss@^6.0.1:
 
 gatsby-plugin-react-helmet-canonical-urls@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet-canonical-urls/-/gatsby-plugin-react-helmet-canonical-urls-1.4.0.tgz#9a0f3a6e75b0ff54c6a8e70c2bc48219903a8296"
   integrity sha512-5g2eqFNh8GSCTvL25sNm84IJ6G79qKHSnOa9druxBj6x5Iw3EujZMv6I4nGMlW5EZlaSf9D5QHNGypUW6idPTg==
   dependencies:
     "@babel/runtime" "^7.3.1"


### PR DESCRIPTION
## What do these changes do?

1. Adds [trailingSlash](https://www.gatsbyjs.com/docs/reference/release-notes/v4.7/#trailingslash-option) config setting.
2. Appends trailing slashes to paths in sitemap if they are lacking them. 
3. Adds canonical plugin to add canonical meta tags to pages.

This creates consistency with the marketing site & our SEO efforts.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [ ] Hotfix
