### PR TITLE
Personal access token doc update

### DIFF
--- a/docs/dashboard-guides/personal-access-token.mdx
+++ b/docs/dashboard-guides/personal-access-token.mdx
@@ -8,7 +8,7 @@ aliases: ["Personal access token", "Access token"]
 To consume all the public RudderStack APIs, you need an access token associated with your RudderStack account. This guide describes the steps to generate a **personal access token** and the operations associated with it.
 
 <div class="warningBlock">
-Only the RudderStack Cloud users with <Link to="/dashboard-guides/teammates/#read-write-user">Read-Write</Link> or <Link to="/dashboard-guides/teammates/#admin">Admin</Link> permissions can create and use the personal access tokens in their workspace.
+You can create and use the personal access tokens with the permissions specific to your role type. For example, <Link to="/dashboard-guides/user-management/#read-only">Read-only</Link> users can create access tokens with only read-only privileges, <Link to="/dashboard-guides/user-management/#read-write">Read-Write</Link> users with read-only and read-write privileges, and <Link to="/dashboard-guides/user-management/#admin">Admin</Link> users with all the privileges.
 </div>
 
 ## Generating a personal access token


### PR DESCRIPTION
## What do these changes do?

> Updated info block on the user permissions for creating and using the access token.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
