### PR TITLE
GitHub Repo link updates

### DIFF
--- a/DESTINATION_TEMPLATE.mdx
+++ b/DESTINATION_TEMPLATE.mdx
@@ -14,7 +14,7 @@ aliases: ["dest_name","dest_name_2"]  // These alias values are used to optimize
 [Destination](Link)- Add some introduction about the destination platform.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/<dest_name>">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/<dest_name>">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/activecampaign.mdx
+++ b/docs/destinations/streaming-destinations/activecampaign.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports ActiveCampaign as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/active_campaign">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/active_campaign">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/adjust.mdx
+++ b/docs/destinations/streaming-destinations/adjust.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports Adjust as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/adj">GitHub repository</a>. You can also refer to the specific repositories for the <a href="https://github.com/rudderlabs/rudder-integration-adjust-android">Android</a> and <a href="https://github.com/rudderlabs/rudder-integration-adjust-ios">iOS</a> implementations.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/adj">GitHub repository</a>. You can also refer to the specific repositories for the <a href="https://github.com/rudderlabs/rudder-integration-adjust-android">Android</a> and <a href="https://github.com/rudderlabs/rudder-integration-adjust-ios">iOS</a> implementations.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/adobe-analytics/adobe-analytics-web-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/adobe-analytics/adobe-analytics-web-device-mode.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/AdobeAnalytics">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/AdobeAnalytics">GitHub repository</a>.
 </div>
 
 ## Initialization

--- a/docs/destinations/streaming-destinations/airship.mdx
+++ b/docs/destinations/streaming-destinations/airship.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports Airship as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/airship">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/airship">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/amazon-eventbridge.mdx
+++ b/docs/destinations/streaming-destinations/amazon-eventbridge.mdx
@@ -9,7 +9,7 @@ description: >-
 RudderStack supports Amazon EventBridge as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/eventbridge">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/eventbridge">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/amazon-kinesis-firehose.mdx
+++ b/docs/destinations/streaming-destinations/amazon-kinesis-firehose.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to K
 RudderStack supports Amazon Kinesis Firehose as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/firehose">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/firehose">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/amazon-kinesis.mdx
+++ b/docs/destinations/streaming-destinations/amazon-kinesis.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports Amazon Kinesis as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/kinesis">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/kinesis">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/amazon-s3.mdx
+++ b/docs/destinations/streaming-destinations/amazon-s3.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack lets you configure Amazon S3 as a destination where you can seamlessly store your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/s3">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/s3">GitHub repository</a>.
 </div>
 
 ## Setting up Amazon S3

--- a/docs/destinations/streaming-destinations/amplitude.mdx
+++ b/docs/destinations/streaming-destinations/amplitude.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports sending events from the RudderStack SDKs to Amplitude through our data plane and Web connection mode.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/am">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/am">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/appcues.mdx
+++ b/docs/destinations/streaming-destinations/appcues.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports sending your event data to Appcues from our native web SDKs, to help you understand your customers better.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/appcues">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/appcues">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/appsflyer.mdx
+++ b/docs/destinations/streaming-destinations/appsflyer.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports AppsFlyer as a destination to which you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/af">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/af">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/attentive-tag.mdx
+++ b/docs/destinations/streaming-destinations/attentive-tag.mdx
@@ -10,7 +10,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports Attentive Tag as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/attentive_tag">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/attentive_tag">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/attribution.mdx
+++ b/docs/destinations/streaming-destinations/attribution.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack supports Attribution as a destination to which you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/attribution">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/attribution">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/autopilot.mdx
+++ b/docs/destinations/streaming-destinations/autopilot.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 RudderStack allows you to configure Autopilot as a destination to which you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/autopilot">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/autopilot">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/awin.mdx
+++ b/docs/destinations/streaming-destinations/awin.mdx
@@ -6,7 +6,7 @@ description: Step-by-step guide on sending your event data from RudderStack to A
 [Awin](https://www.Awin.com/) is an affiliate marketing program that connects advertisers and affiliates of all sizes. It provides a network of affiliate partners, click tracing and tracking, advertiser directory, reports and analytics, and more.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/awin">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/awin">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/aws-personalize.mdx
+++ b/docs/destinations/streaming-destinations/aws-personalize.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide  on sending your event data from RudderStack to 
 RudderStack supports AWS Personalize as a destination where you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/personalize">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/personalize">GitHub repository</a>.
 </div>
 
 <div class="infoBlock">

--- a/docs/destinations/streaming-destinations/azure-event-hubs.mdx
+++ b/docs/destinations/streaming-destinations/azure-event-hubs.mdx
@@ -15,7 +15,7 @@ For more information, refer to the Event Hubs' [**pricing page**](https://azure.
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/azure_event_hub">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/azure_event_hub">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/blueshift.mdx
+++ b/docs/destinations/streaming-destinations/blueshift.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to B
 RudderStack supports Blueshift as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/blueshift">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/blueshift">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/branchio.mdx
+++ b/docs/destinations/streaming-destinations/branchio.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to B
 RudderStack supports Branch as a destination where you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/branch">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/branch">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/braze.mdx
+++ b/docs/destinations/streaming-destinations/braze.mdx
@@ -9,7 +9,7 @@ aliases: ["Braze destination"]
 RudderStack supports Braze as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/braze">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/braze">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/campaign-manager-360.mdx
+++ b/docs/destinations/streaming-destinations/campaign-manager-360.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to C
 RudderStack supports the Campaign Manager 360's [Conversions API](https://developers.google.com/doubleclick-advertisers/rest/v4/conversions) which lets advertisers provide information about the offline conversions directly to Campaign Manager 360.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/campaign_manager">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/campaign_manager">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/candu.mdx
+++ b/docs/destinations/streaming-destinations/candu.mdx
@@ -9,7 +9,7 @@ RudderStack supports Candu as a destination platform where you can send your eve
 
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/candu">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/candu">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/clevertap.mdx
+++ b/docs/destinations/streaming-destinations/clevertap.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to C
 You can now send your event data directly to CleverTap through RudderStack.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/clevertap">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/clevertap">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/clickup.mdx
+++ b/docs/destinations/streaming-destinations/clickup.mdx
@@ -9,7 +9,7 @@ aliases: ["ClickUp destination"]
 RudderStack supports ClickUp as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/clickup">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/clickup">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/confluent-cloud.mdx
+++ b/docs/destinations/streaming-destinations/confluent-cloud.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to C
 RudderStack allows you to seamlessly configure Confluent Cloud as a destination to send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/confluent_cloud">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/confluent_cloud">GitHub repository</a>.
 </div>
 
 ## Configuring Confluent Cloud in RudderStack

--- a/docs/destinations/streaming-destinations/custify.mdx
+++ b/docs/destinations/streaming-destinations/custify.mdx
@@ -9,7 +9,7 @@ aliases: ["Custify destination"]
 RudderStack supports Custify as a destination where you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/custify">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/custify">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/customer.io.mdx
+++ b/docs/destinations/streaming-destinations/customer.io.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to C
 RudderStack supports Customer.io as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/customerio">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/customerio">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/dcm-floodlight/dcm-floodlight-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/dcm-floodlight/dcm-floodlight-device-mode.mdx
@@ -6,7 +6,7 @@ description: Detailed technical documentation on sending events to DCM Floodligh
 RudderStack lets you send your event data to DCM Floodlight destination via the <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link> using the native web SDK. RudderStack uses global site tagging in device mode.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/DCMFloodlight/">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/DCMFloodlight/">GitHub repository</a>.
 </div>
 
 ## Track

--- a/docs/destinations/streaming-destinations/delighted.mdx
+++ b/docs/destinations/streaming-destinations/delighted.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to D
 RudderStack supports Delighted as a destination to which you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/delighted">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/delighted">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/digitalocean-spaces.mdx
+++ b/docs/destinations/streaming-destinations/digitalocean-spaces.mdx
@@ -9,7 +9,7 @@ DigitalOcean Spaces is an S3-compatible object storage service that lets you sto
 RudderStack allows you to configure Spaces as a destination to which you can dump your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/digital_ocean_spaces">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/digital_ocean_spaces">GitHub repository</a>.
 </div>
 
 ## Setting up Spaces

--- a/docs/destinations/streaming-destinations/drip/drip-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/drip/drip-cloud-mode.mdx
@@ -10,7 +10,7 @@ For more information on sending events via the cloud mode, refer to the <Link to
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/drip">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/drip">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/drip/drip-web-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/drip/drip-web-device-mode.mdx
@@ -12,7 +12,7 @@ For more information on sending events via the device mode, refer to the <Link t
 </div>
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/Drip">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/Drip">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/engage/engage-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/engage/engage-cloud-mode.mdx
@@ -7,7 +7,7 @@ aliases: ["Engage destination"]
 RudderStack lets you send your event data to Engage via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/engage/engage-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/engage/engage-device-mode.mdx
@@ -7,7 +7,7 @@ aliases: ["Engage destination"]
 RudderStack lets you send your event data to Engage via the <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link> using the native web SDK. 
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/facebook-app-events.mdx
+++ b/docs/destinations/streaming-destinations/facebook-app-events.mdx
@@ -10,7 +10,7 @@ description: >-
 RudderStack supports Facebook App Events as a destination to which you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/fb">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/fb">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/fb-custom-audience.mdx
+++ b/docs/destinations/streaming-destinations/fb-custom-audience.mdx
@@ -15,7 +15,7 @@ The user information in your events may include email, phone number, gender, etc
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/fb_custom_audience">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/fb_custom_audience">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/fb-offline-conversions.mdx
+++ b/docs/destinations/streaming-destinations/fb-offline-conversions.mdx
@@ -6,7 +6,7 @@ description: Step-by-step guide on sending your event data from RudderStack to F
 [Facebook Offline Conversions](https://www.facebook.com/business/help/1142103235885551?id=565900110447546) lets you measure your sales in the offline world, resulting through your online Facebook ads. It helps you leverage the offline events data by tracking the in-store purchases, phone orders, bookings, etc.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/facebook_offline_conversions">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/facebook_offline_conversions">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/fb-pixel.mdx
+++ b/docs/destinations/streaming-destinations/fb-pixel.mdx
@@ -10,7 +10,7 @@ RudderStack leverages the <a href="https://developers.facebook.com/docs/marketin
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/facebook_pixel">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/facebook_pixel">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/gainsight-px.mdx
+++ b/docs/destinations/streaming-destinations/gainsight-px.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to G
 RudderStack supports Gainsight PX as a destination to which you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/gainsight_px">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/gainsight_px">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/gainsight.mdx
+++ b/docs/destinations/streaming-destinations/gainsight.mdx
@@ -12,7 +12,7 @@ RudderStack lets you send your event data from a variety of sources to Gainsight
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/gainsight">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/gainsight">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/google-analytics-360.mdx
+++ b/docs/destinations/streaming-destinations/google-analytics-360.mdx
@@ -10,7 +10,7 @@ description: >-
 RudderStack supports sending real-time customer events to Google Analytics 360.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/ga360">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/ga360">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/google-analytics-4/google-analytics-4-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/google-analytics-4/google-analytics-4-cloud-mode.mdx
@@ -18,7 +18,7 @@ Note that Google Analytics 4 **does not officially support a complete server-to-
 />
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/ga4">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/ga4">GitHub repository</a>.
 </div>
 
 ## Tagging methods

--- a/docs/destinations/streaming-destinations/google-analytics-4/google-analytics-4-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/google-analytics-4/google-analytics-4-device-mode.mdx
@@ -12,7 +12,7 @@ For more information on sending events via the device mode, refer to the <Link t
 </div>
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/GA4">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/GA4">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/google-analytics-ga.mdx
+++ b/docs/destinations/streaming-destinations/google-analytics-ga.mdx
@@ -9,7 +9,7 @@ description: >-
 RudderStack supports Google Analytics as a destination and makes requests to its endpoints through the [Google Analytics Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/v1).
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/ga">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/ga">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/google-cloud-storage.mdx
+++ b/docs/destinations/streaming-destinations/google-cloud-storage.mdx
@@ -10,7 +10,7 @@ description: >-
 RudderStack allows you to add Google Cloud Storage as a destination to which you can send your event data from any source reliably.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/gcs">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/gcs">GitHub repository</a>.
 </div>
 
 ## Setting up Google Cloud Storage

--- a/docs/destinations/streaming-destinations/google-pub-sub.mdx
+++ b/docs/destinations/streaming-destinations/google-pub-sub.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to G
 RudderStack allows you to configure Google Pub/Sub as a destination and send your event data to it directly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/googlepubsub">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/googlepubsub">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/google-sheets.mdx
+++ b/docs/destinations/streaming-destinations/google-sheets.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to G
 RudderStack allows you to configure Google Sheets as a destination and send your event data to it directly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/googlesheets">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/googlesheets">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/heap.io.mdx
+++ b/docs/destinations/streaming-destinations/heap.io.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to H
 RudderStack supports Heap.io as a destination to which you can send your event data in real-time.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/heap">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/heap">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/hubspot/hubspot-cloud-mode/index.mdx
+++ b/docs/destinations/streaming-destinations/hubspot/hubspot-cloud-mode/index.mdx
@@ -8,7 +8,7 @@ RudderStack lets you send your event data to HubSpot via the <Link to="/destinat
 
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/hs">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/hs">GitHub repository</a>.
 </div>
 
 ## Links

--- a/docs/destinations/streaming-destinations/hubspot/hubspot-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/hubspot/hubspot-device-mode.mdx
@@ -6,7 +6,7 @@ description: Detailed technical documentation on sending events to HubSpot via d
 RudderStack supports the following API calls while sending data to Hubspot via web <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link> using the [legacy API](https://legacydocs.hubspot.com/docs/overview?_ga=2.34803302.670362313.1663315856-97001172.1658910392).
 
 <div class="infoBlock">
-Find the open source code for HubSpot's web device mode in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/HubSpot">GitHub repository</a>.
+Find the open source code for HubSpot's web device mode in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/HubSpot">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/indicative.mdx
+++ b/docs/destinations/streaming-destinations/indicative.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to I
 RudderStack supports Indicative as a destination to which you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/indicative">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/indicative">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/intercom.mdx
+++ b/docs/destinations/streaming-destinations/intercom.mdx
@@ -6,7 +6,7 @@ description: Step-by-step guide on sending your event data from RudderStack to I
 [Intercom](https://www.intercom.com/) is a real-time business messaging platform that lets you bring together and manage all your customer life cycle activities in a single platform.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/intercom">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/intercom">GitHub repository</a>.
 </div>
 
 <div class="warningBlock">

--- a/docs/destinations/streaming-destinations/iterable/iterable-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/iterable/iterable-cloud-mode.mdx
@@ -7,7 +7,7 @@ aliases: ["Iterable destination"]
 RudderStack lets you send your event data to Iterable via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/iterable">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/iterable">GitHub repository</a>.
 </div>
 
 <div class="infoBlock">

--- a/docs/destinations/streaming-destinations/iterable/iterable-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/iterable/iterable-device-mode.mdx
@@ -11,7 +11,7 @@ You can use this connection mode to dynamically send web in-app messages to your
 </div>
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/Iterable">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/Iterable">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/june/june-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/june/june-cloud-mode.mdx
@@ -6,7 +6,7 @@ description:  Detailed technical documentation on sending events to June using t
 RudderStack lets you send your event data to June via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open-source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/june">GitHub repository</a>.
+Find the open-source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/june">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/june/june-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/june/june-device-mode.mdx
@@ -6,7 +6,7 @@ description: Detailed technical documentation on sending events to June using th
 RudderStack lets you send your event data to June destination via the <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link> using the native web SDK.
 
 <div class="infoBlock">
-Find the open-source code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/June">GitHub repository</a>.
+Find the open-source code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/June">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/kafka.mdx
+++ b/docs/destinations/streaming-destinations/kafka.mdx
@@ -7,7 +7,7 @@ aliases: ["Apache Kafka", "Apache Kafka destination"]
 [Apache Kafka](https://kafka.apache.org/) is a popular distributed streaming platform used for building realtime data pipelines and streaming apps.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/kafka">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/kafka">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/keen.mdx
+++ b/docs/destinations/streaming-destinations/keen.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to K
 RudderStack supports S2S \(Server to Server\) cloud mode and Web Native SDK for integration with Keen. You can thus send event data attached to Keen collections using RudderStack APIs.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/keen">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/keen">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/kissmetrics.mdx
+++ b/docs/destinations/streaming-destinations/kissmetrics.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to K
 RudderStack supports sending your events from cloud mode S2S \(Server to Server\) and Web Native SDKs by calling our APIs.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/kissmetrics">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/kissmetrics">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/klaviyo.mdx
+++ b/docs/destinations/streaming-destinations/klaviyo.mdx
@@ -10,7 +10,7 @@ Klaviyo also offers features such as trend reports, cohort analysis, and various
 RudderStack supports Klaviyo as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/klaviyo">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/klaviyo">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/kochava.mdx
+++ b/docs/destinations/streaming-destinations/kochava.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to K
 RudderStack allows you to send relevant events to Kochava through a S2S \(Server-to-Server\) integration with the platform.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/kochava">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/kochava">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/kustomer.mdx
+++ b/docs/destinations/streaming-destinations/kustomer.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to K
 You can now send your event data directly to Kustomer via RudderStack.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/kustomer">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/kustomer">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/leanplum.mdx
+++ b/docs/destinations/streaming-destinations/leanplum.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to L
 RudderStack allows you to configure Leanplum as a destination and send your event data to it directly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/leanplum">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/leanplum">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/lytics.mdx
+++ b/docs/destinations/streaming-destinations/lytics.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to L
 RudderStack supports Lytics as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/lytics">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/lytics">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/mailchimp.mdx
+++ b/docs/destinations/streaming-destinations/mailchimp.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to M
 RudderStack supports Mailchimp as a destination to which you can seamlessly send your event data. Also, you can add people to your Mailchimp list via a simple `identify` call.
 
 <div class="successBlock">
-Find the open-source transformer code for this destination in our <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/mailchimp">GitHub repository</a>.
+Find the open-source transformer code for this destination in our <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/mailchimp">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/mailjet.mdx
+++ b/docs/destinations/streaming-destinations/mailjet.mdx
@@ -7,7 +7,7 @@ description: >-
 [Mailjet](https://www.mailjet.com/) is a popular email marketing and delivery platform. It lets you create and send impactful email marketing campaigns, newsletters, and automated emails to grow your business.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/mailjet">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/mailjet">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/marketo-lead-import.mdx
+++ b/docs/destinations/streaming-destinations/marketo-lead-import.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide to send your leads data from RudderStack to Mark
 RudderStack supports Marketo Lead Import as a destination to which you can send large amounts of lead records asynchronously via Marketo's [bulk API](https://developers.marketo.com/rest-api/bulk-import/bulk-lead-import/).
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/marketo_bulk_upload">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/marketo_bulk_upload">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/marketo.mdx
+++ b/docs/destinations/streaming-destinations/marketo.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to M
 RudderStack supports Marketo as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/marketo">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/marketo">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/microsoft-azure-blob-storage.mdx
+++ b/docs/destinations/streaming-destinations/microsoft-azure-blob-storage.mdx
@@ -9,7 +9,7 @@ description: >-
 RudderStack supports sending your event data from a variety of sources to your Azure Blob Storage container.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/azure_blob">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/azure_blob">GitHub repository</a>.
 </div>
 
 ## Setting up Azure Blob Storage

--- a/docs/destinations/streaming-destinations/minio.mdx
+++ b/docs/destinations/streaming-destinations/minio.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to M
 RudderStack allows you to configure MinIO as a destination to which you can dump your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/minio">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/minio">GitHub repository</a>.
 </div>
 
 ## Setting up MinIO

--- a/docs/destinations/streaming-destinations/mixpanel.mdx
+++ b/docs/destinations/streaming-destinations/mixpanel.mdx
@@ -9,7 +9,7 @@ aliases: ["Mixpanel destination"]
 RudderStack supports Mixpanel as a destination where you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/mp">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/mp">GitHub repository</a>.
 </div>
 
 <YouTube

--- a/docs/destinations/streaming-destinations/moengage.mdx
+++ b/docs/destinations/streaming-destinations/moengage.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending events from RudderStack to MoEngage.
 RudderStack supports MoEngage as a destination to seamlessly send your event data in real-time.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/moengage">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/moengage">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/monday.mdx
+++ b/docs/destinations/streaming-destinations/monday.mdx
@@ -9,7 +9,7 @@ aliases: ["Monday destination"]
 RudderStack supports monday.com as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/monday">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/monday">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/monetate.mdx
+++ b/docs/destinations/streaming-destinations/monetate.mdx
@@ -10,7 +10,7 @@ Monetate is a unique, all-in-one personalization solution aimed especially at ma
 RudderStack allows you to send your event data from your client-side or server-side components to Monetate. This guide will help you set up, configure, and use Monetate for your project.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/monetate">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/monetate">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/pardot.mdx
+++ b/docs/destinations/streaming-destinations/pardot.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to P
 RudderStack supports Pardot as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/pardot">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/pardot">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/pinterest-ads/pinterest-ads-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/pinterest-ads/pinterest-ads-cloud-mode.mdx
@@ -17,7 +17,7 @@ To use Pinterest Tag's cloud mode (Pinterest conversions API), you need to conta
 
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/pinterest_tag">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/pinterest_tag">GitHub repository</a>.
 </div>
 
 ## Track

--- a/docs/destinations/streaming-destinations/pinterest-ads/pinterest-ads-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/pinterest-ads/pinterest-ads-device-mode.mdx
@@ -6,7 +6,7 @@ description: Detailed technical documentation on sending events to Pinterest Tag
 RudderStack lets you send your event data to Pinterest Tag using Pinterest's `pintrk` conversion tag via the <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link>.
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/PinterestTag">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/PinterestTag">GitHub repository</a>.
 </div>
 
 

--- a/docs/destinations/streaming-destinations/posthog/posthog-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/posthog/posthog-cloud-mode.mdx
@@ -7,7 +7,7 @@ aliases: ["PostHog cloud mode destination"]
 RudderStack lets you send your event data to PostHog via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/posthog">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/posthog">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/profitwell/profitwell-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/profitwell/profitwell-cloud-mode.mdx
@@ -10,7 +10,7 @@ For more information on sending events via the RudderStack Cloud mode, refer to 
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/profitwell">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/profitwell">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/redis.mdx
+++ b/docs/destinations/streaming-destinations/redis.mdx
@@ -16,7 +16,7 @@ It is highly recommended that you keep your Redis instance inside a private netw
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/redis">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/redis">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/refiner/refiner-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/refiner/refiner-cloud-mode.mdx
@@ -7,7 +7,7 @@ aliases: ["Refiner destination"]
 RudderStack lets you send your event data to Refiner via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/refiner">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/refiner">GitHub repository</a>.
 </div>
 
 <YouTube

--- a/docs/destinations/streaming-destinations/revenue-cat.mdx
+++ b/docs/destinations/streaming-destinations/revenue-cat.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to R
 RudderStack supports Revenue Cat as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/revenue_cat">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/revenue_cat">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/rockerbox/rockerbox-cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/rockerbox/rockerbox-cloud-mode.mdx
@@ -6,7 +6,7 @@ description:  Detailed technical documentation on sending events to Rockerbox us
 RudderStack lets you send your event data to Rockerbox via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/rockerbox">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/rockerbox">GitHub repository</a>.
 </div>
 
 ## Track

--- a/docs/destinations/streaming-destinations/rockerbox/rockerbox-device-mode.mdx
+++ b/docs/destinations/streaming-destinations/rockerbox/rockerbox-device-mode.mdx
@@ -6,7 +6,7 @@ description: Detailed technical documentation on sending events to Rockerbox usi
 RudderStack lets you send your event data to Rockerbox via the <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link> using the native web SDK. 
 
 <div class="infoBlock">
-Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/integrations/Rockerbox">GitHub repository</a>.
+Find the open source JavaScript SDK code for this destination in the <a href="https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/Rockerbox">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/salesforce.mdx
+++ b/docs/destinations/streaming-destinations/salesforce.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to S
 RudderStack lets you identify your leads in Salesforce without having to use the REST APIs.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/salesforce" target="_blank">GitHub repository</a> .
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/salesforce" target="_blank">GitHub repository</a> .
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/sendgrid.mdx
+++ b/docs/destinations/streaming-destinations/sendgrid.mdx
@@ -8,7 +8,7 @@ aliases: ["SendGrid destination"]
 [SendGrid](https://sendgrid.com/) is a cloud-based email marketing platform built for marketers and developers. It helps businesses deliver billions of transactional and marketing emails every month.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/sendgrid">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/sendgrid">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/serenytics.mdx
+++ b/docs/destinations/streaming-destinations/serenytics.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide to send your event data from RudderStack to Sere
 With this integration you can use the full range of RudderStack tools to create functions, transform and filter your events on their way to the Serenytics warehouse where you can then visualize your data.
 
 <div class="infoBlock">
-Find the open source code for this destination in this <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/serenytics">GitHub repository</a>.
+Find the open source code for this destination in this <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/serenytics">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/sfmc.mdx
+++ b/docs/destinations/streaming-destinations/sfmc.mdx
@@ -9,7 +9,7 @@ description: >-
 RudderStack allows you to integrate your source to Salesforce Marketing Cloud and send data to Salesforce Marketing Data Extensions.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/sfmc">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/sfmc">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/shynet.mdx
+++ b/docs/destinations/streaming-destinations/shynet.mdx
@@ -8,7 +8,7 @@ Shynet is an open source self-hosted web analytics platform which works without 
 RudderStack supports Shynet as a destination to which you can seamlessly send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/shynet">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/shynet">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/signl4.mdx
+++ b/docs/destinations/streaming-destinations/signl4.mdx
@@ -11,7 +11,7 @@ RudderStack also supports SIGNL4 as a source. Refer to the <Link to="/sources/ev
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/signl4">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/signl4">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/slack.mdx
+++ b/docs/destinations/streaming-destinations/slack.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to S
 RudderStack supports Slack as a destination where you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/slack">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/slack">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/snapchat-conversion.mdx
+++ b/docs/destinations/streaming-destinations/snapchat-conversion.mdx
@@ -12,7 +12,7 @@ The events should be generated at least 28 days before to be eligible for report
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/snapchat_conversion">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/snapchat_conversion">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/snapchat-custom-audience.mdx
+++ b/docs/destinations/streaming-destinations/snapchat-custom-audience.mdx
@@ -8,7 +8,7 @@ aliases: ["Snapchat Custom Audience", "Snapchat custom audience destination"]
 [Snapchat Custom Audience](https://businesshelp.snapchat.com/s/article/create-sam-audience?language=en_US) matches data from your Snapchat customer list (email, phone number, or mobile advertiser ID) with the Snapchat community.
 
 <div class="infoBlock">
-Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/snapchat_custom_audience">GitHub repository</a>.
+Find the open source code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/snapchat_custom_audience">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/splitio.mdx
+++ b/docs/destinations/streaming-destinations/splitio.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on setting up Split.io as a destination in Rudde
 RudderStack supports Split.io as a destination to which you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/splitio">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/splitio">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/tiktok-ads.mdx
+++ b/docs/destinations/streaming-destinations/tiktok-ads.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to T
 RudderStack supports TikTok Ads as a destination where you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/tiktok_ads">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/tiktok_ads">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/trengo.mdx
+++ b/docs/destinations/streaming-destinations/trengo.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to T
 RudderStack allows you to configure Trengo as a destination to which you can send your event data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/trengo">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/trengo">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/userlist.mdx
+++ b/docs/destinations/streaming-destinations/userlist.mdx
@@ -12,7 +12,7 @@ This destination is supported by the Userlist team. You can contact the Userlist
 </div>
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/userlist">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/userlist">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/vero/cloud-mode.mdx
+++ b/docs/destinations/streaming-destinations/vero/cloud-mode.mdx
@@ -7,7 +7,7 @@ description: >-
 RudderStack lets you send your event data to Vero via the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link>.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/vero">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/vero">GitHub repository</a>.
 </div>
 
 ## Identify

--- a/docs/destinations/streaming-destinations/yahoo-dsp.mdx
+++ b/docs/destinations/streaming-destinations/yahoo-dsp.mdx
@@ -9,7 +9,7 @@ description: >-
 RudderStack supports Yahoo DSP as a destination where you can send your event data seamlessly.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/yahoo_dsp">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/yahoo_dsp">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/streaming-destinations/zendesk.mdx
+++ b/docs/destinations/streaming-destinations/zendesk.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide on sending your event data from RudderStack to Z
 RudderStack supports Zendesk as a destination to which you can seamlessly send your customer data.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/zendesk">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/zendesk">GitHub repository</a>.
 </div>
 
 ## Getting started

--- a/docs/destinations/warehouse-destinations/azure-datalake.mdx
+++ b/docs/destinations/warehouse-destinations/azure-datalake.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/azure_datalake">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/azure_datalake">GitHub repository</a>.
 </div>
 
 ## Configuring Azure data lake destination in RudderStack

--- a/docs/destinations/warehouse-destinations/azure-synapse.mdx
+++ b/docs/destinations/warehouse-destinations/azure-synapse.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open-source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/azure_synapse">GitHub repository</a>.
+Find the open-source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/azure_synapse">GitHub repository</a>.
 </div>
 
 ## Prerequisites

--- a/docs/destinations/warehouse-destinations/bigquery.mdx
+++ b/docs/destinations/warehouse-destinations/bigquery.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open-source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/bq">GitHub repository</a>.
+Find the open-source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/bq">GitHub repository</a>.
 </div>
 
 ## Setting up the BigQuery project

--- a/docs/destinations/warehouse-destinations/clickhouse.mdx
+++ b/docs/destinations/warehouse-destinations/clickhouse.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/clickhouse">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/clickhouse">GitHub repository</a>.
 </div>
 
 ## Setting user permissions in ClickHouse

--- a/docs/destinations/warehouse-destinations/postgresql.mdx
+++ b/docs/destinations/warehouse-destinations/postgresql.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/postgres">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/postgres">GitHub repository</a>.
 </div>
 
 ## Setting user permissions in PostgreSQL

--- a/docs/destinations/warehouse-destinations/redshift.mdx
+++ b/docs/destinations/warehouse-destinations/redshift.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/rs">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/rs">GitHub repository</a>.
 </div>
 
 ## Setting up a Redshift cluster

--- a/docs/destinations/warehouse-destinations/s3-datalake.mdx
+++ b/docs/destinations/warehouse-destinations/s3-datalake.mdx
@@ -12,7 +12,7 @@ For more information on how the events are mapped to the tables in S3 data lake 
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/s3_datalake">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/s3_datalake">GitHub repository</a>.
 </div>
 
 ## S3 permissions for data lake destination

--- a/docs/destinations/warehouse-destinations/snowflake.mdx
+++ b/docs/destinations/warehouse-destinations/snowflake.mdx
@@ -10,7 +10,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/snowflake">GitHub</a> repository.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/snowflake">GitHub</a> repository.
 </div>
 
 ## Setting user permissions in Snowflake

--- a/docs/destinations/warehouse-destinations/sql-server.mdx
+++ b/docs/destinations/warehouse-destinations/sql-server.mdx
@@ -12,7 +12,7 @@ Refer to the <Link to="/destinations/warehouse-destinations/warehouse-schema/">W
 </div>
 
 <div class="successBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/mssql">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/mssql">GitHub repository</a>.
 </div>
 
 ## Setting user permissions in SQL Server

--- a/docs/destinations/webhooks.mdx
+++ b/docs/destinations/webhooks.mdx
@@ -11,7 +11,7 @@ Webhooks let you send the events generated via RudderStack's <Link to="/sources/
 Once webhooks are enabled as a destination in your dashboard, RudderStack forwards the SDK events to your configured webhook endpoint.
 
 <div class="infoBlock">
-Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/v0/destinations/webhook">GitHub repository</a>.
+Find the open source transformer code for this destination in the <a href="https://github.com/rudderlabs/rudder-transformer/tree/master/src/v0/destinations/webhook">GitHub repository</a>.
 </div>
 
 ## Getting started


### PR DESCRIPTION
## What do these changes do?

Updated links for Transformer and JS SDK repo (added src folder)
