### PR TITLE
Session tracking docs optimization

### DIFF
--- a/docs/sources/event-streams/sdks/session-tracking/faq.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/faq.mdx
@@ -74,7 +74,7 @@ When an application is closed completely and launched from scratch, RudderStack 
 
 The scope of manual session tracking depends on whether the automatic session tracking feature is enabled.
 
-- If automatic session tracking is **enabled**: On the next app launch (from scratch), RudderStack clears the manual session even if <Link to="/sources/event-streams/sdks/session-tracking/#manual-session-tracking">`endSession()`</Link> is not called and generates a new **automatic** session.
+- If automatic session tracking is **enabled**: On the next app launch (from scratch), RudderStack clears the manual session even if <Link to="/sources/event-streams/sdks/session-tracking/manual-session-tracking/">`endSession()`</Link> is not called and generates a new **automatic** session.
 - If automatic session tracking is **disabled**: On the next app launch, the manual session will still be active and cleared only when the user ends the session using `endSession()`.
 
 ### Where does RudderStack store the `sessionId`, last event time, and automatic session tracking status?

--- a/docs/sources/event-streams/sdks/session-tracking/faq.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/faq.mdx
@@ -70,7 +70,7 @@ If the time between closing the tab and reopening it is less than the session ti
 
 When an application is closed completely and launched from scratch, RudderStack checks if the inactivity timeout of the previous automatically tracked session has elapsed. If yes, RudderStack creates a new session, otherwise it continues the previous session.
 
-<h3 id="#manual-session-tracking-persistence">What is the scope of persistence in case of manual session tracking?</h3>
+### What is the scope of persistence in case of manual session tracking?
 
 The scope of manual session tracking depends on whether the automatic session tracking feature is enabled.
 

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -12,7 +12,7 @@ A single session can contain multiple page views or screen views, events, social
 
 With the help of RudderStack's **session tracking** feature, you can gather the event tracking metrics and combine it with the session metadata to better understand the user's product journey and analyze their behavior. You can also use the resulting insights to identify problems and optimization opportunities in your product workflow.
 
-## Session tracking in RudderStack
+## Session tracking in RudderStack SDKs
 
 The following RudderStack SDKs support the session tracking feature:
 
@@ -23,7 +23,7 @@ The following RudderStack SDKs support the session tracking feature:
 | <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link> | <strong>v1.7.0</strong> |
 
 <div class="infoBlock">
-If the session tracking feature is enabled, you can expect the following properties in your event's <code class="inline-code">context</code> object:
+You can expect the following properties in your event's <code class="inline-code">context</code> object when session tracking is enabled:
 <ul>
 <li><code class="inline-code">sessionId</code> (Number): The unique session ID.</li>
 <li><code class="inline-code">sessionStart</code> (Boolean): Present in the first event, indicating the start of the session.</li>

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -31,7 +31,7 @@ You can expect the following properties in your event's <Link to="/event-spec/st
 </div>
 
 <div class="warningBlock">
-It is strongly recommended to send any other session-related information in the event's traits or properties. When session tracking is enabled, RudderStack overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object.
+It is strongly recommended to send any other session-related information in the event's traits or properties as RudderStack's automatic session tracking overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object.
 </div>
 
 ## Automatic session tracking

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -4,17 +4,15 @@ description: Detailed technical description of RudderStack's session tracking fe
 aliases: ["session tracking", "user session"]
 ---
 
-## What is a session?
-
 A session is a group of user interactions with your website or mobile app within a given time frame. It is usually triggered when a user opens a mobile app or a website in their browser and ends after a particular period of inactivity.
 
 <div class="infoBlock">
 A single session can contain multiple page views or screen views, events, social interactions, and e-commerce transactions.
 </div>
 
-## Session tracking in RudderStack
+With the help of RudderStack's **session tracking** feature, you can gather the event tracking metrics and combine it with the session metadata to better understand the user's product journey and analyze their behavior. You can also use the resulting insights to identify problems and optimization opportunities in your product workflow.
 
-You can use RudderStack's session tracking feature to determine the average time users spend on an app and how they engage with it. By combining the session metadata with the usage data like event tracking, you can better understand the user's product journey and analyze their behavior effectively. You can also use the resulting insights to identify problems and optimization opportunities in your product workflow.
+## Session tracking in RudderStack
 
 The following RudderStack SDKs support the session tracking feature:
 
@@ -24,10 +22,13 @@ The following RudderStack SDKs support the session tracking feature:
 | <Link to="/sources/event-streams/sdks/rudderstack-android-sdk/">Android</Link> | <strong>v1.7.0</strong> |
 | <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link> | <strong>v1.7.0</strong> |
 
-If the session tracking feature is enabled, you can expect the following properties in your event's `context` object:
-
-- `sessionId` (Number): The unique session ID.
-- `sessionStart` (Boolean): Present in the first event, indicating the start of the session.
+<div class="infoBlock">
+If the session tracking feature is enabled, you can expect the following properties in your event's <code class="inline-code">context</code> object:
+<ul>
+<li><code class="inline-code">sessionId</code> (Number): The unique session ID.</li>
+<li><code class="inline-code">sessionStart</code> (Boolean): Present in the first event, indicating the start of the session.</li>
+</ul>
+</div>
 
 <div class="warningBlock">
 The session tracking feature overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object. Hence, it is strongly recommended to send any session-related information in the event's traits or properties.
@@ -35,30 +36,34 @@ The session tracking feature overrides any <code class="inline-code">sessionId</
 
 ## Automatic session tracking
 
-**By default, the above-mentioned RudderStack SDKs automatically track the user sessions**. This means that RudderStack automatically determines the start and end of a session depending on the inactivity time configured in the SDK.
+**By default, the RudderStack SDKs automatically track the user sessions**. This means that RudderStack automatically determines the start and end of a session depending on the inactivity time configured in the SDK.
 
 <div class="infoBlock">
-RudderStack also lets you start and end user sessions manually. Refer to the <Link to="#manual-session-tracking">Manual session tracking</Link> section below for more information.
+RudderStack also lets you start and end user sessions manually. Refer to the <Link to="/sources/event-streams/sdks/session-tracking/manual-session-tracking">Manual session tracking</Link> guide for more information. <strong>Note that manual session tracking overrides the automatic session tracking</strong>.
 </div>
 
 ### JavaScript SDK
 
-In case of the JavaScript SDK, RudderStack considers the <Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/load-js-sdk/">SDK initialization</Link> as the start of a user session.
+For the JavaScript SDK, RudderStack considers the <Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/load-js-sdk/">SDK initialization</Link> as the start of a user session.
 
-To disable automatic session tracking, you can set the load option `autoTrack` to `false`, as shown:
+To disable automatic session tracking, you can set the `autoTrack` load option to `false`, as shown:
 
 ```javascript
 rudderanalytics.load(WRITE_KEY, DATA_PLANE_URL, {
   sessions: {
-    autoTrack: false,  // Set to false to disable automatic session tracking
+    autoTrack: false,  // Set to true to enable automatic session tracking
   },
   ...<otherLoadOptions>
 });
 ```
 
-By default, a session is active until **30 minutes of inactivity** have elapsed since the last received event. However, you can adjust this limit using the `timeout` load option. 
+### When does a session become inactive?
 
-The following snippet highlights the use of the `timeout` option to set a custom session timeout of 10 minutes:
+By default, a session is active until **30 minutes of inactivity** have elapsed since the last received event. Whenever RudderStack receives a new event, it checks if the inactivity period has elapsed. If yes, it starts a new session with a new `sessionId`. Otherwise, it continues the previous session.
+
+Every time a new event is generated (`track`, `page`, `identify`, etc.), the SDK resets the session expiration time by adding the configured `timeout` (default **30 minutes**) to the last received event's <Link to="/event-spec/standard-events/common-fields/#clock-skew-considerations">`timestamp`</Link>.
+
+You can also adjust the inactivity period using the `timeout` load option. The following snippet highlights the use of the `timeout` option to set a custom session timeout of 10 minutes:
 
 ```javascript
 rudderanalytics.load(WRITE_KEY, DATA_PLANE_URL, {
@@ -69,8 +74,6 @@ rudderanalytics.load(WRITE_KEY, DATA_PLANE_URL, {
   ...<otherLoadOptions>
 });
 ```
-
-Every time a new event is generated (`track`, `page`, `identify`, etc.), the SDK resets the session expiration time by adding the configured `timeout` (default **30 minutes**) to the last received event's <Link to="/event-spec/standard-events/common-fields/#clock-skew-considerations">`timestamp`</Link>.
 
 <div class="infoBlock">
 For more information on how session tracking works in the JavaScript SDK, refer to the <Link to="#session-tracking-flow">Session tracking flow</Link> section below.
@@ -172,44 +175,10 @@ To disable automatic session tracking, set `withAutoSessionTracking` to `false`.
 
 By default, a session is active until **5 minutes of inactivity** have elapsed. However, you can adjust this limit using the `sessionTimeoutMillis` load option, as seen in the above snippets.
 
-If the duration between the last received event and the next `Application Opened` event is more than `sessionTimeoutMillis`, RudderStack starts a new session. Otherwise, it continues the previous session.
+If the duration between the last received event and the next `Application Opened` event is more than `sessionTimeoutMillis`, RudderStack **automatically** starts a new session. Otherwise, it continues the previous session.
 
 <div class="infoBlock">
 For more information on how session tracking works in the mobile SDKs, refer to the <Link to="#session-tracking-flow">Session tracking flow</Link> section below.
-</div>
-
-## Manual session tracking
-
-<div class="infoBlock">
-This section is applicable for all the supported RudderStack SDKs (<Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript</Link>, <Link to="/sources/event-streams/sdks/rudderstack-android-sdk/">Android</Link>, and <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link>).
-</div>
-
-RudderStack also supports manual session tracking using the following methods that indicate the start and end of a user session:
-
-<table>
-  <tr>
-    <th width="180px">Method</th>
-    <th width="180px">Parameters</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td rowspan="2"><code class="inline-code">startSession()</code></td>
-    <td>-</td>
-    <td>If no parameter is passed, RudderStack creates a new session and passes the current <code class="inline-code">timestamp</code> as the <Link to="/sources/event-streams/sdks/session-tracking/faq/#how-does-rudderstack-determine-the-sessionid"><code class="inline-code">sessionId</code></Link>.</td>
-  </tr>
-  <tr>
-    <td><code class="inline-code">sessionId</code><br /> <span style="color: #4D4DFF;font-size:12px;">Long integer with minimum length of 10 characters.</span></td>
-    <td> You can pass a custom <code class="inline-code">sessionId</code> and trigger a new user session. <br/><br/> It is <strong>not recommended</strong> to use a decimal number as the <code class="inline-code">sessionId</code>. </td>
-  </tr>
-  <tr>
-    <td><code class="inline-code">endSession()</code></td>
-    <td>-</td>
-    <td>RudderStack clears the <code class="inline-code">sessionId</code> and ends the session.</td>
-  </tr>
-</table>
-
-<div class="warningBlock">
-Manual session tracking overrides automatic session tracking. If <Link to="#automatic-session-tracking">automatic session tracking</Link> is enabled and you call the <code class="inline-code">startSession()</code> API, then RudderStack will disable automatic session tracking <strong>until the app is closed completely</strong>. For more information, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/#manual-session-tracking-persistence">FAQ</Link> section.
 </div>
 
 ## Session tracking flow
@@ -228,7 +197,8 @@ If session tracking is enabled in the JavaScript SDK, the flow is as explained b
 For more information on how RudderStack calculates <code class="inline-code">sessionId</code>, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/#how-does-rudderstack-determine-the-sessionid">FAQ</Link> guide. 
 </div>
 
-3. Finally, the SDK updates the session expiration time, that is, the last event's <Link to="/event-spec/standard-events/common-fields/#clock-skew-considerations">`timestamp`</Link> + `timeout` (default **30 minutes**).
+3. The SDK records the user events and the session is active until the `timeout` (default **30 minutes** of inactivity) period has elapsed since the last received event. If yes, it starts a new session with a new `sessionId`.
+4. Otherwise, the SDK updates the session expiration time by adding the last event's <Link to="/event-spec/standard-events/common-fields/#clock-skew-considerations">`timestamp`</Link> to the `timeout` period (default **30 minutes**).
 
 The following diagram summarizes the workflow:
 
@@ -245,7 +215,7 @@ If session tracking is enabled in the mobile SDKs, the flow is as explained belo
 For more information on how RudderStack calculates <code class="inline-code">sessionId</code>, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/#how-does-rudderstack-determine-the-sessionid">FAQ</Link> guide. 
 </div>
 
-3. The SDK records the user events and the session is active until more than `sessionTimeoutMillis` (default **5 minutes**) of inactivity have elapsed since the last received event.
+3. The SDK records the user events and the session is active until more than `sessionTimeoutMillis` (default **5 minutes**) period of inactivity has elapsed since the last received event.
 
 <div class="infoBlock">
 For more information, refer to the <Link to="#session-expiration-in-mobile-sdks">Session expiration in the mobile SDKs</Link> section above.

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -23,7 +23,7 @@ The following RudderStack SDKs support the session tracking feature:
 | <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link> | <strong>v1.7.0</strong> |
 
 <div class="infoBlock">
-You can expect the following properties in your event's <code class="inline-code">context</code> object when session tracking is enabled:
+You can expect the following properties in your event's <Link to="/event-spec/standard-events/common-fields/#contextual-fields"><code class="inline-code">context</code></Link> object when session tracking is enabled:
 <ul>
 <li><code class="inline-code">sessionId</code> (Number): The unique session ID.</li>
 <li><code class="inline-code">sessionStart</code> (Boolean): Present in the first event, indicating the start of the session.</li>
@@ -31,7 +31,7 @@ You can expect the following properties in your event's <code class="inline-code
 </div>
 
 <div class="warningBlock">
-The session tracking feature overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object. Hence, it is strongly recommended to send any session-related information in the event's traits or properties.
+It is strongly recommended to send any other session-related information in the event's traits or properties. When session tracking is enabled, RudderStack overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object.
 </div>
 
 ## Automatic session tracking

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -31,7 +31,7 @@ You can expect the following properties in your event's <Link to="/event-spec/st
 </div>
 
 <div class="warningBlock">
-It is strongly recommended to send any other session-related information in the event's traits or properties as RudderStack's automatic session tracking overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object.
+It is strongly recommended to send any other session-related information in the event's traits or properties as RudderStack's <Link to="#automatic-session-tracking">automatic session tracking</Link> overrides any <code class="inline-code">sessionId</code> set in the event's <code class="inline-code">context</code> object.
 </div>
 
 ## Automatic session tracking

--- a/docs/sources/event-streams/sdks/session-tracking/manual-session-tracking.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/manual-session-tracking.mdx
@@ -1,0 +1,36 @@
+---
+title: "Manual Session Tracking"
+description: Manually tracking user sessions using the RudderStack SDKs.
+---
+
+<div class="infoBlock">
+This guide is applicable for all the RudderStack SDKs (<Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript</Link>, <Link to="/sources/event-streams/sdks/rudderstack-android-sdk/">Android</Link>, and <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link>) that support the session tracking feature.
+</div>
+
+RudderStack supports manual session tracking using the following methods that indicate the start and end of a user session:
+
+<table>
+  <tr>
+    <th width="180px">Method</th>
+    <th width="180px">Parameters</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td rowspan="2"><code class="inline-code">startSession()</code></td>
+    <td>-</td>
+    <td>If no parameter is passed, RudderStack creates a new session and passes the current <code class="inline-code">timestamp</code> as the <Link to="/sources/event-streams/sdks/session-tracking/faq/#how-does-rudderstack-determine-the-sessionid"><code class="inline-code">sessionId</code></Link>.</td>
+  </tr>
+  <tr>
+    <td><code class="inline-code">sessionId</code><br /> <span style="color: #4D4DFF;font-size:12px;">Long integer with minimum length of 10 characters.</span></td>
+    <td> You can pass a custom <code class="inline-code">sessionId</code> and trigger a new user session. <br/><br/> It is <strong>not recommended</strong> to use a decimal number as the <code class="inline-code">sessionId</code>. </td>
+  </tr>
+  <tr>
+    <td><code class="inline-code">endSession()</code></td>
+    <td>-</td>
+    <td>RudderStack clears the <code class="inline-code">sessionId</code> and ends the session.</td>
+  </tr>
+</table>
+
+<div class="warningBlock">
+Manual session tracking overrides automatic session tracking. If <Link to="/sources/event-streams/sdks/session-tracking/#automatic-session-tracking">automatic session tracking</Link> is enabled and you call the <code class="inline-code">startSession()</code> API, then RudderStack will disable automatic session tracking <strong>until the app is closed completely</strong>. For more information, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/">FAQ</Link> guide.
+</div>

--- a/docs/sources/event-streams/sdks/session-tracking/manual-session-tracking.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/manual-session-tracking.mdx
@@ -3,7 +3,7 @@ title: "Manual Session Tracking"
 description: Manually tracking user sessions using the RudderStack SDKs.
 ---
 
-RudderStack supports manual session tracking that let you define the start and end of a user session.
+RudderStack supports manual session tracking that lets you define the start and end of a user session.
 
 ## Manual session tracking methods
 
@@ -18,11 +18,11 @@ The RudderStack SDKs (<Link to="/sources/event-streams/sdks/rudderstack-javascri
   <tr>
     <td rowspan="2"><code class="inline-code">startSession()</code></td>
     <td>-</td>
-    <td>If no parameter is passed, RudderStack creates a new session and passes the current <code class="inline-code">timestamp</code> as the <Link to="/sources/event-streams/sdks/session-tracking/faq/#how-does-rudderstack-determine-the-sessionid"><code class="inline-code">sessionId</code></Link>.</td>
+    <td>If you don't pass any parameter, RudderStack creates a new session and passes the current <code class="inline-code">timestamp</code> as the <Link to="/sources/event-streams/sdks/session-tracking/faq/#how-does-rudderstack-determine-the-sessionid"><code class="inline-code">sessionId</code></Link>.</td>
   </tr>
   <tr>
     <td><code class="inline-code">sessionId</code><br /> <span style="color: #4D4DFF;font-size:12px;">Long integer with minimum length of 10 characters.</span></td>
-    <td> You can pass a custom <code class="inline-code">sessionId</code> and trigger a new user session. <br/><br/> It is <strong>not recommended</strong> to use a decimal number as the <code class="inline-code">sessionId</code>. </td>
+    <td>If you pass a custom <code class="inline-code">sessionId</code> parameter, RudderStack triggers a new user session. <br/><br/> It is <strong>not recommended</strong> to use a decimal number as the <code class="inline-code">sessionId</code>. </td>
   </tr>
   <tr>
     <td><code class="inline-code">endSession()</code></td>
@@ -32,8 +32,12 @@ The RudderStack SDKs (<Link to="/sources/event-streams/sdks/rudderstack-javascri
 </table>
 
 <div class="warningBlock">
-<strong>Manual session tracking overrides <Link to="/sources/event-streams/sdks/session-tracking/#automatic-session-tracking">automatic session tracking</Link></strong>. <br /><br />If automatic session tracking is enabled and you call the <code class="inline-code">startSession()</code> method, then RudderStack disables it <strong>until the app is closed completely</strong>. <br /><br />For more information on the persistence scope of manual session tracking, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/#what-is-the-scope-of-persistence-in-case-of-manual-session-tracking">FAQ</Link> guide.
+<strong>Manual session tracking overrides <Link to="/sources/event-streams/sdks/session-tracking/#automatic-session-tracking">automatic session tracking</Link></strong>. 
 </div>
+
+Note that if automatic session tracking is enabled and you call the <code class="inline-code">startSession()</code> method, then RudderStack disables automatic session tracking **until the app is closed completely**. Upon restarting the app, the RudderStack SDKs resume automatic session tracking.
+
+For more information on the persistence scope of manual session tracking, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/#what-is-the-scope-of-persistence-in-case-of-manual-session-tracking">FAQ</Link> guide.
 
 ## Sample snippets
 

--- a/docs/sources/event-streams/sdks/session-tracking/manual-session-tracking.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/manual-session-tracking.mdx
@@ -3,11 +3,11 @@ title: "Manual Session Tracking"
 description: Manually tracking user sessions using the RudderStack SDKs.
 ---
 
-<div class="infoBlock">
-This guide is applicable for all the RudderStack SDKs (<Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript</Link>, <Link to="/sources/event-streams/sdks/rudderstack-android-sdk/">Android</Link>, and <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link>) that support the session tracking feature.
-</div>
+RudderStack supports manual session tracking that let you define the start and end of a user session.
 
-RudderStack supports manual session tracking using the following methods that indicate the start and end of a user session:
+## Manual session tracking methods
+
+The RudderStack SDKs (<Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript</Link>, <Link to="/sources/event-streams/sdks/rudderstack-android-sdk/">Android</Link>, and <Link to="/sources/event-streams/sdks/rudderstack-ios-sdk/">iOS</Link>) support the following manual session tracking methods:
 
 <table>
   <tr>
@@ -32,5 +32,90 @@ RudderStack supports manual session tracking using the following methods that in
 </table>
 
 <div class="warningBlock">
-Manual session tracking overrides automatic session tracking. If <Link to="/sources/event-streams/sdks/session-tracking/#automatic-session-tracking">automatic session tracking</Link> is enabled and you call the <code class="inline-code">startSession()</code> API, then RudderStack will disable automatic session tracking <strong>until the app is closed completely</strong>. For more information, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/">FAQ</Link> guide.
+<strong>Manual session tracking overrides <Link to="/sources/event-streams/sdks/session-tracking/#automatic-session-tracking">automatic session tracking</Link></strong>. <br /><br />If automatic session tracking is enabled and you call the <code class="inline-code">startSession()</code> method, then RudderStack disables it <strong>until the app is closed completely</strong>. <br /><br />For more information on the persistence scope of manual session tracking, refer to the <Link to="/sources/event-streams/sdks/session-tracking/faq/#what-is-the-scope-of-persistence-in-case-of-manual-session-tracking">FAQ</Link> guide.
 </div>
+
+## Sample snippets
+
+The following snippets highlight the use of the manual session tracking methods:
+
+### JavaScript
+
+```javascript
+rudderanalytics.startSession() // Starts a new user session and automatically assigns a session ID.
+
+rudderanalytics.startSession(sessionId) // Passes a custom session ID while creating a new session.
+
+rudderanalytics.endSession() // Ends the user session and clears the session ID.
+```
+
+### Android
+
+<Tabs>
+  <TabList>
+    <Tab>Kotlin</Tab>
+    <Tab>Java</Tab>
+  </TabList>
+    <TabPanels>
+      <TabPanel>
+<span>
+
+```kotlin
+rudderClient.startSession() // Starts a new user session and automatically assigns a session ID.
+
+rudderClient.startSession(sessionId) // Passes a custom session ID while creating a new session.
+
+rudderClient.endSession() // Ends the user session and clears the session ID.
+```
+</span>
+      </TabPanel>
+      <TabPanel>
+<span>
+
+```java
+rudderClient.startSession(); // Starts a new user session and automatically assigns a session ID.
+
+rudderClient.startSession(sessionId); // Passes a custom session ID while creating a new session.
+
+rudderClient.endSession(); // Ends the user session and clears the session ID.
+```
+</span>
+      </TabPanel>
+    </TabPanels>
+</Tabs>
+
+
+### iOS
+
+<Tabs>
+  <TabList>
+    <Tab>Swift</Tab>
+    <Tab>Objective C</Tab>
+  </TabList>
+    <TabPanels>
+      <TabPanel>
+<span>
+
+```swift
+RSClient.sharedInstance()?.startSession() // Starts a new user session and automatically assigns a session ID.
+
+RSClient.sharedInstance()?.startSession(sessionId) // Passes a custom session ID while creating a new session.
+
+RSClient.sharedInstance()?.endSession() // Ends the user session and clears the session ID.
+```
+</span>
+      </TabPanel>
+      <TabPanel>
+<span>
+
+```objectivec
+[[RSClient sharedInstance] startSession]; // Starts a new user session and automatically assigns a session ID.
+
+[[RSClient sharedInstance] startSession:sessionId]; // Passes a custom session ID while creating a new session.
+
+[[RSClient sharedInstance] endSession]; // Ends the user session and clears the session ID.
+```
+</span>
+      </TabPanel>
+    </TabPanels>
+</Tabs>

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -302,15 +302,15 @@ export const jsonData = [
                         link: "/sources/event-streams/sdks/session-tracking/",
                         content: [
                             {
-                                title: "FAQ",
-                                link: "/sources/event-streams/sdks/session-tracking/faq/",
-                                content: [],
-                              },
-                              {
                                 title: "Manual Session Tracking",
                                 link: "/sources/event-streams/sdks/session-tracking/manual-session-tracking/",
                                 content: [],
                               },
+                            {
+                                title: "FAQ",
+                                link: "/sources/event-streams/sdks/session-tracking/faq/",
+                                content: [],
+                              }
                         ]
                     },
                     {

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -306,6 +306,11 @@ export const jsonData = [
                                 link: "/sources/event-streams/sdks/session-tracking/faq/",
                                 content: [],
                               },
+                              {
+                                title: "Manual Session Tracking",
+                                link: "/sources/event-streams/sdks/session-tracking/manual-session-tracking/",
+                                content: [],
+                              },
                         ]
                     },
                     {


### PR DESCRIPTION
## What do these changes do?

> Updated session tracking docs to clarify how inactivity is handled.
> Separated manual session tracking from automatic to not have any scope for confusion.

Preview: [Here](https://rudderstack-docs-1cmeb2p4h-rudder-stack.vercel.app/sources/event-streams/sdks/session-tracking/)

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
