### PR TITLE
PHP SDK initialization snippet update

### DIFF
--- a/docs/sources/event-streams/sdks/rudderstack-php-sdk.mdx
+++ b/docs/sources/event-streams/sdks/rudderstack-php-sdk.mdx
@@ -55,8 +55,8 @@ Rudder::init(WRITE_KEY, array(
   "data_plane_url" => DATA_PLANE_URL,
   "consumer"       => "lib_curl", // fork_curl
   "debug"          => true,
-  "max_queue_size" => 10000,
-  "batch_size"     => 100,
+  "max_queue_size" => 10000, // Temporary queue to store the in-memory events, defaults to 1000
+  "batch_size"     => 100, // Number of events sent in a batch request, defaults to 100
   "ssl"            => true // defaults to true
 ));
 ```

--- a/docs/sources/event-streams/sdks/rudderstack-php-sdk.mdx
+++ b/docs/sources/event-streams/sdks/rudderstack-php-sdk.mdx
@@ -55,7 +55,7 @@ Rudder::init(WRITE_KEY, array(
   "data_plane_url" => DATA_PLANE_URL,
   "consumer"       => "lib_curl", // fork_curl
   "debug"          => true,
-  "max_queue_size" => 10000, // Maximum number of events to be stored by the in-memory queue, defaults to 1000
+  "max_queue_size" => 10000, // Maximum number of events stored in the in-memory queue, defaults to 1000
   "batch_size"     => 100, // Number of events sent in a batch request, defaults to 100
   "ssl"            => true // defaults to true
 ));

--- a/docs/sources/event-streams/sdks/rudderstack-php-sdk.mdx
+++ b/docs/sources/event-streams/sdks/rudderstack-php-sdk.mdx
@@ -55,7 +55,7 @@ Rudder::init(WRITE_KEY, array(
   "data_plane_url" => DATA_PLANE_URL,
   "consumer"       => "lib_curl", // fork_curl
   "debug"          => true,
-  "max_queue_size" => 10000, // Temporary queue to store the in-memory events, defaults to 1000
+  "max_queue_size" => 10000, // Maximum number of events to be stored by the in-memory queue, defaults to 1000
   "batch_size"     => 100, // Number of events sent in a batch request, defaults to 100
   "ssl"            => true // defaults to true
 ));


### PR DESCRIPTION
## What do these changes do?

> Added descriptions for the `max_queue_size` and `batch_size` parameters in the initialization snippet.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
