### PR TITLE
Updated messaging in Tracking Plan docs

### DIFF
--- a/docs/features/data-governance/tracking-plans/index.mdx
+++ b/docs/features/data-governance/tracking-plans/index.mdx
@@ -52,8 +52,8 @@ The Tracking Plans feature currently supports only <Link to="/event-spec/standar
 
 ### Does RudderStack propagate the context related to any tracking plan violations?
 
-Currently, RudderStack propagates any context related to the tracking plan violations **only to the data warehouses** but not all the destinations. You can use this context in your <Link to="/transformations">Transformations</Link> for filtering or modifying the events before they reach the destination.
+RudderStack propagates any context related to the tracking plan violations to your destinations. You can use this context in your <Link to="/transformations">Transformations</Link> for filtering or modifying the events before they reach the destination.
 
 If you have defined the <Link to="/features/data-governance/tracking-plans/tracking-plan-spreadsheet/#global-settings">tracking plan global settings</Link> such that **Allow unplanned events** is set to `FALSE`, the events that are explicitly dropped via the tracking plan will not reach any destination.
 
-
+<br />


### PR DESCRIPTION
## What do these changes do?

> Context related to TP violations is sent to all the destinations, including warehouse and cloud destinations unless explicitly directed otherwise.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
