### PR TITLE
Destination Filtering update

### DIFF
--- a/docs/user-guides/how-to-guides/how-to-filter-selective-destinations.mdx
+++ b/docs/user-guides/how-to-guides/how-to-filter-selective-destinations.mdx
@@ -3,11 +3,7 @@ title: "How to Filter Selective Destinations"
 description: Filter selective destinations while sending your event data via RudderStack.
 ---
 
-RudderStack lets you send your event data only to certain intended destinations by filtering out the rest. For the <Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript SDK</Link>, you can do this by passing an `integrations` object in the `options` parameter of the event method. For most of the other SDKs, you can use the `integrations` object parameter for the associated event. 
-
-<div class="infoBlock">
-This feature is currently supported only for cloud mode integrations. For more information on cloud mode, refer to the <Link to="/destinations/rudderstack-connection-modes/">RudderStack Connection Modes</Link> guide.
-</div>
+RudderStack lets you send your event data only to certain intended destinations by filtering out the rest. For the <Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript SDK</Link>, you can do this by passing an `integrations` object in the `options` parameter of the event method. For most of the other SDKs, you can use the `integrations` object parameter for the associated event.
 
 ## How it works
 

--- a/docs/user-guides/how-to-guides/how-to-filter-selective-destinations.mdx
+++ b/docs/user-guides/how-to-guides/how-to-filter-selective-destinations.mdx
@@ -3,7 +3,7 @@ title: "How to Filter Selective Destinations"
 description: Filter selective destinations while sending your event data via RudderStack.
 ---
 
-RudderStack lets you send your event data only to certain intended destinations by filtering out the rest. For the <Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript SDK</Link>, you can do this by passing an `integrations` object in the `options` parameter of the event method. For most of the other SDKs, you can use the `integrations` object parameter for the associated event.
+RudderStack lets you send your event data only to certain intended destinations by filtering out the rest. For the <Link to="/sources/event-streams/sdks/rudderstack-javascript-sdk/">JavaScript SDK</Link>, you can do this by passing an `integrations` object in the `options` parameter of the event method. For most of the other SDKs, you can use the `integrations` object parameter for the associated event
 
 ## How it works
 


### PR DESCRIPTION
## What do these changes do?

> Removed note re: cloud support for `integrations` object for event filtering.

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix
