### PR TITLE
Update session tracking docs

### DIFF
--- a/docs/sources/event-streams/sdks/session-tracking/faq.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/faq.mdx
@@ -5,6 +5,10 @@ description: Answers to the generally asked questions related to RudderStack's s
 
 ## Generic
 
+### Do the RudderStack server-side SDKs support the automatic session tracking feature?
+
+No, the server-side SDKs do not support automatic session tracking. However, you can create your own session start and end events as backend events using the SDKs.
+
 ### How does RudderStack determine the `sessionId`?
 
 RudderStack passes the event's `timestamp` (in milliseconds) as the `sessionId`. 

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -237,7 +237,7 @@ The following diagram summarizes the workflow:
 
 ## Supported downstream tools
 
-RudderStack supports forwarding the `sessionId` and `sessionStart` fields to all the cloud and warehouse destinations.
+RudderStack supports forwarding the `sessionId` and `sessionStart` fields to all the <Link to="/destinations/streaming-destinations/">cloud</Link> and <Link to="/destinations/warehouse-destinations/">warehouse</Link> destinations.
 
 It is important to note the following:
 

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -36,7 +36,11 @@ It is strongly recommended to send any other session-related information in the 
 
 ## Automatic session tracking
 
-**By default, the RudderStack SDKs automatically track the user sessions**. This means that RudderStack automatically determines the start and end of a session depending on the inactivity time configured in the SDK.
+**By default, the RudderStack SDKs(JavaScript, Android, and iOS) automatically track the user sessions**. This means that RudderStack automatically determines the start and end of a session depending on the inactivity time configured in the SDK.
+
+<div class="dangerBlock">
+The server-side SDKs do not support automatic session tracking.
+</div>
 
 <div class="infoBlock">
 RudderStack also lets you start and end user sessions manually. Refer to the <Link to="/sources/event-streams/sdks/session-tracking/manual-session-tracking">Manual session tracking</Link> guide for more information. <strong>Note that manual session tracking overrides the automatic session tracking</strong>.
@@ -237,12 +241,29 @@ The following diagram summarizes the workflow:
 
 ## Supported downstream tools
 
-RudderStack supports forwarding the `sessionId` and `sessionStart` fields to all the <Link to="/destinations/streaming-destinations/">cloud</Link> and <Link to="/destinations/warehouse-destinations/">warehouse</Link> destinations.
+The RudderStack SDKs support sending the `sessionId` and `sessionStart` fields to all the <Link to="/destinations/streaming-destinations/">cloud</Link> and <Link to="/destinations/warehouse-destinations/">warehouse</Link> destinations, **within the event's `context`**.
 
 It is important to note the following:
 
 - RudderStack passes the `sessionId` to all the subsequent events in the `context.sessionId` field.
 - RudderStack sets the `context.sessionStart` field to `true` in the first event to indicate the start of the session.
+
+RudderStack maps `sessionId` to specific fields **only** in case of the following two destinations:
+
+<table style="table-layout: fixed; width: 100%;" >
+<tr>
+  <td style="width:40%;"><strong>Destination</strong></td>
+  <td style="width:60%;"><strong>Notes</strong></td>
+</tr>
+<tr>
+  <td><Link to="/destinations/streaming-destinations/amplitude/">Amplitude</Link></td>
+  <td>RudderStack maps <code class="inline-code">sessionId</code> to Amplitude's <code class="inline-code">session_id</code> field. <br /><br />For more information, refer to the <a href="https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#keys-for-the-event-argument:~:text=to%20occur%20simultaneously.-,session_id,-Optional.%20Long.%20The">Amplitude documentation</a>.</td>
+</tr>
+<tr>
+  <td><Link to="/destinations/streaming-destinations/mixpanel/">Mixpanel</Link></td>
+  <td><ul><li>RudderStack passes <code class="inline-code">$session_id</code> under the event properties.</li><li>Mixpanel doesn't have any specific field for <code class="inline-code">$session_id</code> but you can use this field in the reports.</li></ul></td>
+</tr>
+</table>
 
 ## FAQ
 

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -237,25 +237,11 @@ The following diagram summarizes the workflow:
 
 ## Supported downstream tools
 
-RudderStack supports forwarding the `sessionId` and `sessionStart` fields to the following downstream destinations:
-
-<table style="table-layout: fixed; width: 100%;" >
-<tr>
-  <td style="width:40%;"><strong>Destination</strong></td>
-  <td style="width:60%;"><strong>Notes</strong></td>
-</tr>
-<tr>
-  <td><Link to="/destinations/streaming-destinations/amplitude/">Amplitude</Link></td>
-  <td>RudderStack sends the <code class="inline-code">sessionId</code> parameter in the event which is mapped to <code class="inline-code">session_id</code> in Amplitude. For more information, refer to the <a href="https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#keys-for-the-event-argument:~:text=to%20occur%20simultaneously.-,session_id,-Optional.%20Long.%20The">Amplitude documentation</a>.</td>
-</tr>
-<tr>
-  <td><Link to="/destinations/streaming-destinations/mixpanel/">Mixpanel</Link></td>
-  <td><ul><li>RudderStack passes <code class="inline-code">$session_id</code> under the event properties.</li><li>Mixpanel doesn't have any specific field for <code class="inline-code">$session_id</code> but you can use this field in the reports.</li></ul></td>
-</tr>
-</table>
+RudderStack supports forwarding the `sessionId` and `sessionStart` fields to all the cloud and warehouse destinations.
 
 It is important to note the following:
-- RudderStack passes the `sessionId` to the subsequent events in the `context.sessionId` field.
+
+- RudderStack passes the `sessionId` to all the subsequent events in the `context.sessionId` field.
 - RudderStack sets the `context.sessionStart` field to `true` in the first event to indicate the start of the session.
 
 ## FAQ

--- a/docs/sources/event-streams/sdks/session-tracking/index.mdx
+++ b/docs/sources/event-streams/sdks/session-tracking/index.mdx
@@ -36,7 +36,7 @@ It is strongly recommended to send any other session-related information in the 
 
 ## Automatic session tracking
 
-**By default, the RudderStack SDKs(JavaScript, Android, and iOS) automatically track the user sessions**. This means that RudderStack automatically determines the start and end of a session depending on the inactivity time configured in the SDK.
+**By default, the RudderStack SDKs (JavaScript, Android, and iOS) automatically track the user sessions**. This means that RudderStack automatically determines the start and end of a session depending on the inactivity time configured in the SDK.
 
 <div class="dangerBlock">
 The server-side SDKs do not support automatic session tracking.


### PR DESCRIPTION
## What do these changes do?

> Simplified the section on the supported destinations for the SDKs' session tracking feature (mentioned support for cloud and warehouse destinations both instead of just Amplitude and Mixpanel)

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
