### PR TITLE
S3 permissions update

### DIFF
--- a/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
+++ b/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
@@ -88,6 +88,7 @@ To use your own S3 bucket for RudderStack to dump the events, you need to perfor
         {
             "Effect": "Allow",
             "Action": [
+                "s3:GetObject",
                 "s3:PutObject",
                 "s3:AbortMultipartUpload"
             ],
@@ -147,5 +148,3 @@ Once the bucket is created, add the required permissions to it by following the 
 <img src="../../assets/screenshot-2020-08-05-at-11.53.34-am.png" alt="Go to Permissions" />
 
 * Finally the download the JSON file containing the required permissions.
-
-

--- a/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
+++ b/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
@@ -16,13 +16,13 @@ Follow the steps in this guide if you want RudderStack to back up the events in 
 
 ## Bucket configuration settings
 
-If you are using **RudderStack Open Source** and want to use your own bucket to dump the events, you will need to enable and set certain variables in your RudderStack backend.
+If you are using **RudderStack Open Source** and want to use your own bucket to store the events, you will need to enable and set certain variables in your RudderStack backend.
 
 ### Docker setup
 
 #### Storing events into your S3 bucket
 
-To capture the event dumps in your S3 bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
+To capture the events in your S3 bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
 
 ```
 # JOBS_BACKUP_STORAGE_PROVIDER=S3
@@ -39,12 +39,12 @@ Then follow these steps:
 
 <div class="infoBlock">
 The <code class="inline-code">&lt;prefix&gt;</code> value for the <strong><code class="inline-code">JOBS_BACKUP_PREFIX</code></strong> variable refers to the path under the bucket in which RudderStack stores the data. 
-For example, if <strong><code class="inline-code">JOBS_BACKUP_PREFIX</code></strong> is set to <strong><code class="inline-code">prefix</code></strong>  then RudderStack dumps the data in the location <strong><code class="inline-code">&lt;your_s3_bucket&gt;/prefix</code></strong>.
+For example, if <strong><code class="inline-code">JOBS_BACKUP_PREFIX</code></strong> is set to <strong><code class="inline-code">prefix</code></strong>  then RudderStack stores the data in the location <strong><code class="inline-code">&lt;your_s3_bucket&gt;/prefix</code></strong>.
 </div>
 
-#### Dumping events into your GCS bucket
+#### Storing events into your GCS bucket
 
-To capture the event dumps in your GCS bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
+To capture the events in your GCS bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
 
 ```
 # JOBS_BACKUP_STORAGE_PROVIDER=GCS
@@ -64,7 +64,7 @@ Similar to the Docker setup, you can configure your bucket settings by changing 
 
 ## Permissions for Amazon S3
 
-Follow these steps to use your own S3 bucket for RudderStack to dump the events:
+Follow these steps to use your own S3 bucket for RudderStack to store the events:
 
 1. Create a bucket using the Amazon [S3](https://aws.amazon.com/s3/) service.  
 2. Create a new [customer-managed policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_managed-policies.html) with the following JSON:
@@ -92,7 +92,7 @@ Follow these steps to use your own S3 bucket for RudderStack to dump the events:
 
 ## Permissions for GCS
 
-This section lists the steps to use your own GCS bucket for RudderStack to dump the events: 
+This section lists the steps to use your own GCS bucket for RudderStack to store the events: 
 
 Under **Roles** in your GCP dashboard, you need to create a role with the following permissions:
 

--- a/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
+++ b/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
@@ -5,8 +5,8 @@ description: Configure cloud-specific buckets for your event backups.
 
 Depending on your <Link to="/dashboard-guides/data-retention/">data retention policy</Link>, RudderStack stores the following two types of events:
 
-* All the raw events ingested by RudderStack
-* The final event payload along with the error, in case of delivery failures
+* All the raw events ingested by RudderStack.
+* The final event payload along with the error, in case of delivery failures.
 
 <div class="successBlock">
 The events are deleted from the bucket upon successful delivery of the events. <strong>RudderStack does not persist any of the customer data</strong>.
@@ -20,7 +20,7 @@ If you are using **RudderStack Open Source** and want to use your own bucket to 
 
 ### Docker setup
 
-#### Dumping events into your S3 bucket
+#### Storing events into your S3 bucket
 
 To capture the event dumps in your S3 bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
 
@@ -136,4 +136,4 @@ Once the bucket is created, add the required permissions by following the below 
 
 <img src="../../assets/screenshot-2020-08-05-at-11.53.34-am.png" alt="Go to Permissions" />
 
-4. Finally the download the JSON file containing the required permissions.
+4. Finally, download the JSON file containing the required permissions.

--- a/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
+++ b/docs/user-guides/administrators-guide/bucket-configuration-settings.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Bucket Configuration Settings for Event Backups"
-description: Configure your cloud-specific buckets for event backups.
+description: Configure cloud-specific buckets for your event backups.
 ---
 
-RudderStack stores the following two types of events into its cloud-specific bucket:
+Depending on your <Link to="/dashboard-guides/data-retention/">data retention policy</Link>, RudderStack stores the following two types of events:
 
-* All the raw events ingested by RudderStack are stored.
-* In case of delivery failures, the final event payload along with the error is stored.
+* All the raw events ingested by RudderStack
+* The final event payload along with the error, in case of delivery failures
 
 <div class="successBlock">
 The events are deleted from the bucket upon successful delivery of the events. <strong>RudderStack does not persist any of the customer data</strong>.
@@ -14,15 +14,15 @@ The events are deleted from the bucket upon successful delivery of the events. <
 
 Follow the steps in this guide if you want RudderStack to back up the events in your **own** cloud-specific bucket.
 
-## Bucket Configuration Settings
+## Bucket configuration settings
 
-If you are using **open-source RudderStack** and want to use your own bucket to dump the events, you will need to enable and set certain variables in your RudderStack backend.
+If you are using **RudderStack Open Source** and want to use your own bucket to dump the events, you will need to enable and set certain variables in your RudderStack backend.
 
-### Docker Setup
+### Docker setup
 
 #### Dumping events into your S3 bucket
 
-To capture the event dumps in your S3 bucket, uncomment the following lines in your [**docker.env**](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
+To capture the event dumps in your S3 bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
 
 ```
 # JOBS_BACKUP_STORAGE_PROVIDER=S3
@@ -34,23 +34,17 @@ To capture the event dumps in your S3 bucket, uncomment the following lines in y
 
 Then follow these steps:
 
-* Specify your S3 bucket name for the variable `JOBS_BACKUP_BUCKET`.
-* Add the specific AWS IAM keys by following the <Link to="#permissions-for-amazon-s3">Permissions for Amazon S3</Link> section below.
+1. Specify your S3 bucket name for the variable `JOBS_BACKUP_BUCKET`.
+2. Add the specific AWS IAM keys by following the <Link to="#permissions-for-amazon-s3">Permissions for Amazon S3</Link> section below.
 
 <div class="infoBlock">
-The <code class="inline-code">&lt;prefix&gt;</code> value for the <strong><code class="inline-code">JOBS_BACKUP_PREFIX</code></strong> variable refers to the path under the bucket in which RudderStack dumps the data. 
+The <code class="inline-code">&lt;prefix&gt;</code> value for the <strong><code class="inline-code">JOBS_BACKUP_PREFIX</code></strong> variable refers to the path under the bucket in which RudderStack stores the data. 
 For example, if <strong><code class="inline-code">JOBS_BACKUP_PREFIX</code></strong> is set to <strong><code class="inline-code">prefix</code></strong>  then RudderStack dumps the data in the location <strong><code class="inline-code">&lt;your_s3_bucket&gt;/prefix</code></strong>.
-</div>
-
-<div class="successBlock">
-<strong>If you're a RudderStack Pro/Enterprise user, you can share the Access Key ID and Secret Access Key with the RudderStack team by <a href="https://rudderstack.com/join-rudderstack-slack-community">contacting us</a>.</strong>
-
-The RudderStack team will then use the above credentials to authenticate RudderStack and enable it to back up events into your S3 bucket.
 </div>
 
 #### Dumping events into your GCS bucket
 
-To capture the event dumps in your GCS bucket, uncomment the following lines in your [**docker.env**](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
+To capture the event dumps in your GCS bucket, uncomment the following lines in your [docker.env](https://github.com/rudderlabs/rudder-server/blob/master/build/docker.env#L45-L50) file: 
 
 ```
 # JOBS_BACKUP_STORAGE_PROVIDER=GCS
@@ -61,27 +55,21 @@ To capture the event dumps in your GCS bucket, uncomment the following lines in 
 
 Then, follow these steps:
 
-* Specify your GCS bucket name for the variable `JOBS_BACKUP_BUCKET`.
-* Specify the location of the downloaded JSON file containing the required permissions for the variable `GOOGLE_APPLICATION_CREDENTIALS`. You can obtain this JSON file by referring to the <Link to ="#permissions-for-gcs">Permissions for GCS</Link> section below.
-
-<div class="successBlock">
-<strong>If you're a RudderStack Pro/Enterprise user, you can share the downloaded JSON containing the required permissions with the RudderStack team by <a href="https://rudderstack.com/join-rudderstack-slack-community">contacting us</a></strong>.
-
-The RudderStack team will then use this service account JSON file to authenticate RudderStack and dump the events into your GCS bucket.
-</div>
+1. Specify your GCS bucket name for the variable `JOBS_BACKUP_BUCKET`.
+2. Specify the location of the downloaded JSON file containing the required permissions for the variable `GOOGLE_APPLICATION_CREDENTIALS`. You can obtain this JSON file by referring to the <Link to ="#permissions-for-gcs">Permissions for GCS</Link> section below.
 
 ### Kubernetes Setup
 
-Similar to the Docker setup, you can configure your bucket settings by changing the values in the [**values.yaml**](https://github.com/rudderlabs/rudderstack-helm/blob/master/values.yaml#L87) file.
+Similar to the Docker setup, you can configure your bucket settings by changing the values in the [values.yaml](https://github.com/rudderlabs/rudderstack-helm/blob/master/values.yaml#L87) file.
 
 ## Permissions for Amazon S3
 
-To use your own S3 bucket for RudderStack to dump the events, you need to perform the following steps: 
+Follow these steps to use your own S3 bucket for RudderStack to dump the events:
 
-* Create a bucket using the Amazon [**S3**](https://aws.amazon.com/s3/) service.  
-* Create a new customer-managed [**policy**](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_managed-policies.html) with the following JSON:
+1. Create a bucket using the Amazon [S3](https://aws.amazon.com/s3/) service.  
+2. Create a new [customer-managed policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_managed-policies.html) with the following JSON:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -98,53 +86,54 @@ To use your own S3 bucket for RudderStack to dump the events, you need to perfor
 }
 ```
 
-* Create a new group and add the policy created above to this group. 
-* Create a new [**user**](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) in [**Identity and Access Management \(IAM\)**](https://console.aws.amazon.com/iam) with the programmatic access and add the user to the above created group. 
-* Download and note the **Access key ID** and **Secret Access Key**.
+3. Create a new group and add the policy created above to this group. 
+4. Create a new [user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) in [Identity and Access Management \(IAM\)](https://console.aws.amazon.com/iam) with the programmatic access and add the user to the above group. 
+5. Download and note the **Access key ID** and **Secret Access Key**.
 
 ## Permissions for GCS
 
-To use your own GCS bucket for RudderStack to dump the events, you need to perform the following steps: 
+This section lists the steps to use your own GCS bucket for RudderStack to dump the events: 
 
-* Under **Roles** in your GCP dashboard, create a role with the following permissions: 
+Under **Roles** in your GCP dashboard, you need to create a role with the following permissions:
+
   * **storage.objects.create**
   * **storage.objects.get**
 
 <div class="infoBlock">
-It is recommended to add each permission one after the other.
+It is highly recommended to add each permission one after the other.
 </div>
 
 <img src="../../assets/screenshot-2020-08-05-at-11.38.37-am.png" alt="Permission" />
 
-Then, create a service account by following the steps below:
+Then, create a service account by following these steps:
 
-* Assign a name to the service account, as shown:
+1. Assign a name to the service account:
 
 
 <img src="../../assets/screenshot-2020-08-05-at-11.40.12-am (2) (2) (2) (2) (2) (2) (2) (2) (2) (2) (2) (2) (1).png" alt="Assign a name" />
 
-* Add the role you created in the step above.
+2. Add the role you created in step 1.
 
 
 <img src="../../assets/screenshot-2020-08-05-at-11.41.24-am.png" alt="" />
 
-* Create a key with the type JSON and save this file locally, as shown:
+3. Create a key with the type JSON and save this file locally:
 
 
 <img src="../../assets/screenshot-2020-08-05-at-11.49.10-am.png" alt="Create a key" />
 
 
-* Then, create a bucket with the bucket access control set to **Uniform**, as shown:
+4. Then, create a bucket with the bucket access control set to **Uniform**:
 
 
 <img src="../../assets/screenshot-2020-08-05-at-11.52.07-am.png" alt="Create a bucket" />
 
-Once the bucket is created, add the required permissions to it by following the steps below:
+Once the bucket is created, add the required permissions by following the below steps:
 
-* Go to the **Permissions** tab.
-* Then, add the member with the service account created above.
-* Add the role created above.
+1. Go to the **Permissions** tab.
+2. Then, add the member with the service account created above.
+3. Add the role.
 
 <img src="../../assets/screenshot-2020-08-05-at-11.53.34-am.png" alt="Go to Permissions" />
 
-* Finally the download the JSON file containing the required permissions.
+4. Finally the download the JSON file containing the required permissions.


### PR DESCRIPTION
## What do these changes do?

> Added `getObject` action in configuring bucket permissions for event backup and replay
> Minor content cleanup

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
