### PR TITLE
Facebook Pixel doc fix

### DIFF
--- a/docs/destinations/streaming-destinations/fb-pixel.mdx
+++ b/docs/destinations/streaming-destinations/fb-pixel.mdx
@@ -281,7 +281,7 @@ Note that:
 
 - For the `Purchase` standard event, `properties.revenue` is a required field.
 - For the <code class="inline-code">Products Searched</code> event, the <code class="inline-code">query</code> property must be a string.
-- If you do not specify the `currency` field in the `Order Completed` event, RudderStack sets its value to `USD` by default.
+- If you do not specify the `properties.currency` field in the `Order Completed` event, RudderStack sets its value to `USD` by default.
 - If you map an event with the `ViewContent` standard event using the RudderStack dashboard setting and don't send the `products` array in the `message.properties` object, as shown:
 
   ```javascript

--- a/docs/destinations/streaming-destinations/fb-pixel.mdx
+++ b/docs/destinations/streaming-destinations/fb-pixel.mdx
@@ -279,6 +279,7 @@ You can use the <strong>Map your events with Facebook Standard Events</strong> s
 
 Note that:
 
+- For the `Purchase` standard event, `revenue` is a required field.
 - For the <code class="inline-code">Products Searched</code> event, the <code class="inline-code">query</code> property must be a string.
 - You need to specify `currency` in the `Order Completed` event. If not specified, RudderStack will set the default value to `USD`.
 - If you map an event with the `ViewContent` standard event using the RudderStack dashboard setting and don't send the `products` array in the `message.properties` object, as shown:

--- a/docs/destinations/streaming-destinations/fb-pixel.mdx
+++ b/docs/destinations/streaming-destinations/fb-pixel.mdx
@@ -279,9 +279,9 @@ You can use the <strong>Map your events with Facebook Standard Events</strong> s
 
 Note that:
 
-- For the `Purchase` standard event, `revenue` is a required field.
+- For the `Purchase` standard event, `properties.revenue` is a required field.
 - For the <code class="inline-code">Products Searched</code> event, the <code class="inline-code">query</code> property must be a string.
-- You need to specify `currency` in the `Order Completed` event. If not specified, RudderStack will set the default value to `USD`.
+- If you do not specify the `currency` field in the `Order Completed` event, RudderStack sets its value to `USD` by default.
 - If you map an event with the `ViewContent` standard event using the RudderStack dashboard setting and don't send the `products` array in the `message.properties` object, as shown:
 
   ```javascript


### PR DESCRIPTION
## What do these changes do?

> Add a note that `revenue` is a required field for the events mapped to the `Purchase` standard event.

Context: [This Slack thread](https://rudderstack.slack.com/archives/C01E4PLB135/p1675426990331889?thread_ts=1675257762.310809&cid=C01E4PLB135)

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix
