### PR TITLE
Consent management documentation

### DIFF
--- a/docs/sources/event-streams/sdks/consent-management/index.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/index.mdx
@@ -1,0 +1,39 @@
+---
+title: "Consent Management"
+description: Integrate RudderStack with various consent management platforms.
+aliases: ["Consent Management", ""]
+---
+
+Consent managers offer various cookie consent solutions allowing the customers to determine what personal data they want to share with a business. Data protection laws like GDPR, CCPA, etc., require the websites to get user consent for collecting their data through cookies.
+
+<div class="infoBlock">
+Currently, RudderStack only supports the <Link to="/sources/event-streams/sdks/consent-management/onetrust/">OneTrust consent manager</Link>. Support for other consent management tools is coming soon.
+</div>
+
+## FAQ
+
+### Can I integrate the RudderStack JavaScript SDK with any consent manager?
+
+If you are using a consent manager other than <Link to="/sources/event-streams/sdks/consent-management/onetrust/">OneTrust</Link>, you can configure the cookie categories to show on your website whenever a user visits.
+
+Next, you need to create an internal mapping between these cookie categories and the destinations configured in RudderStack. For example:
+
+- Analytical cookie: Amplitude, Google Analytics
+- Targeting cookie: Bing Ads, Google Ads
+- Marketing cookie: Braze, Mailchimp, Customer.io
+
+When the user provides consent, you should fetch the consent (via the API or SDK provided by your consent manager) and filter the destinations depending on the consent. Once you have the list of destinations for which the user has provided consent, you can load the JavaScript SDK only for those destinations.
+
+For example, if a user has provided consent for an analytical cookie, then you can load the JavaScript SDK as shown:
+
+```javascript
+rudderanalytics.load(WRITE_KEY,DATA_PLANE_URL,{
+   integrations: {
+       All: false,
+       "Amplitude": true,
+       "Google Analytics": true
+       // only provide the destinations the user has provide consent for
+   }
+   // pass other initialization options
+});
+```

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/android.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/android.mdx
@@ -1,0 +1,6 @@
+---
+title: "OneTrust-Android SDK Integration"
+description: Integrate the RudderStack Android SDK with OneTrust.
+aliases: ["OneTrust Android SDK"]
+---
+

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/android.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/android.mdx
@@ -4,3 +4,125 @@ description: Integrate the RudderStack Android SDK with OneTrust.
 aliases: ["OneTrust Android SDK"]
 ---
 
+The <Link to="https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-android-sdk/">RudderStack Android SDK</Link> lets you specify the user's consent during initialization.
+
+## Overview
+
+The consent management is designed to be a filter for the event destinations and the natively added factories. Since the SDK initializes the native integration factories during the startup, the user's consent to the cookie categories must be captured by then.
+
+<div class="warningBlock">
+You can add only one consent filter to the Android SDK.
+</div>
+
+For filtering, RudderStack uses the `getConsentStatusForGroupId` method from the OneTrust SDK.
+
+## SDK setup
+
+This setup assumes the Android SDK and the OneTrust SDK is already added to your application.
+
+1. Add OneTrust Consent Filter to your `build.gradle` (module level).
+
+## Usage
+
+The following snippet shows a sample application file to help with the initialization:
+
+```kotlin
+class CustomApplication : Application() {
+    companion object {
+        const val DATA_PLANE_URL = "data_plane_url"
+        const val WRITE_KEY = "write_key"
+    }
+
+    var _rudderClient: RudderClient? = null;
+    val rudderClient
+        get() = _rudderClient
+
+    private val oneTrustEventListener = object : OTEventListener() {
+        override fun onShowBanner(p0: OTUIDisplayReason?) {
+        }
+
+        override fun onHideBanner() {
+
+        }
+
+        override fun onBannerClickedAcceptAll() {
+            createRudderClientWithOneTrust()
+        }
+
+        override fun onBannerClickedRejectAll() {
+            createRudderClientWithOneTrust()
+        }
+
+        override fun onShowPreferenceCenter(p0: OTUIDisplayReason?) {
+        }
+
+        override fun onHidePreferenceCenter() {
+        }
+
+        override fun onPreferenceCenterAcceptAll() {
+            createRudderClientWithOneTrust()
+        }
+
+        override fun onPreferenceCenterRejectAll() {
+            createRudderClientWithOneTrust()
+        }
+
+        override fun onPreferenceCenterConfirmChoices() {
+            createRudderClientWithOneTrust()
+        }
+
+        override fun onShowVendorList() {}
+
+        override fun onHideVendorList() {}
+
+        override fun onVendorConfirmChoices() {
+        }
+
+        override fun allSDKViewsDismissed(p0: String?) {}
+
+        override fun onVendorListVendorConsentChanged(p0: String?, p1: Int) {
+        }
+
+        override fun onVendorListVendorLegitimateInterestChanged(p0: String?, p1: Int) {}
+
+        override fun onPreferenceCenterPurposeConsentChanged(p0: String?, p1: Int) {
+        }
+
+        override fun onPreferenceCenterPurposeLegitimateInterestChanged(p0: String?, p1: Int) {}
+
+    }
+    internal val otPublishersHeadlessSDK by lazy { OTPublishersHeadlessSDK(this) }
+
+    override fun onCreate() {
+        super.onCreate()
+        setupOneTrust()
+    }
+
+    internal fun setupOneTrust() {
+			// set up one trust, 
+      // uncomment the following line and pass the credentials
+			// otPublishersHeadlessSDK.startSDK()
+        otPublishersHeadlessSDK.addEventListener(oneTrustEventListener)
+    }
+
+    private fun createRudderClientWithOneTrust() {
+        _rudderClient = RudderClient.getInstance(
+            this,
+            WRITE_KEY,
+            RudderConfig.Builder()
+                .withDataPlaneUrl(DATA_PLANE_URL)
+                .withLogLevel(RudderLogger.RudderLogLevel.VERBOSE)
+                .withControlPlaneUrl("https://api.dev.rudderlabs.com")
+                .withTrackLifecycleEvents(true)
+                .withRecordScreenViews(false)
+                .withConsentFilter(RudderOneTrustConsentFilter(otPublishersHeadlessSDK))
+                .build()
+            )
+    }
+
+
+    private val otSdkParams
+        get() = OTSdkParams.SdkParamsBuilder.newInstance()
+            .build()
+}
+```

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/android.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/android.mdx
@@ -1,5 +1,5 @@
 ---
-title: "OneTrust-Android SDK Integration"
+title: "OneTrust Consent Management for RudderStack Android SDK"
 description: Integrate the RudderStack Android SDK with OneTrust.
 aliases: ["OneTrust Android SDK"]
 ---

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/index.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "OneTrust Consent Manager"
+description: Integrate RudderStack with the OneTrust consent management platform.
+aliases: ["OneTrust consent manager", "onetrust"]
+---
+
+[OneTrust](https://www.onetrust.com/) is a popular consent management platform that provides data governance, privacy management, and security solutions to thousands of businesses worldwide.
+
+RudderStack supports OneTrust integration with the following SDKs:
+
+- <Link to="/sources/event-streams/sdks/consent-management/onetrust/web/">Web (JavaScript)</Link>
+- <Link to="/sources/event-streams/sdks/consent-management/onetrust/android/">Android</Link>
+- <Link to="/sources/event-streams/sdks/consent-management/onetrust/ios/">iOS</Link>

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/ios.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/ios.mdx
@@ -1,6 +1,224 @@
 ---
-title: "OneTrust-iOS SDK Integration"
+title: "OneTrust Consent Management for RudderStack iOS SDK"
 description: Integrate the RudderStack iOS SDK with OneTrust.
 aliases: ["OneTrust iOS SDK"]
 ---
 
+The <Link to="https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-ios-sdk/">RudderStack iOS SDK</Link> lets you specify the user's consent during initialization.
+
+<div class="infoBlock">
+The RudderStack iOS SDK supports OneTrust consent management from version 1.9.0.
+</div>
+
+This guide lists the steps to:
+
+- Develop a consent interceptor for the iOS SDK.
+- Use the interceptor to initialize the SDK once the user gives their consent.
+
+## Developing a consent interceptor
+
+<Tabs>
+  <TabList>
+    <Tab>Objective-C</Tab>
+    <Tab>Swift</Tab>
+  </TabList>
+    <TabPanels>
+      <TabPanel>
+        <ol>
+            <li>Create a <code class="inline-code">CustomConsentInterceptor.h</code> by extending <code class="inline-code">RSConsentInterceptor</code>, as shown:</li>
+            <br />
+<span>
+
+```objectivec
+#import <Foundation/Foundation.h>
+#import <Rudder/Rudder.h>
+NS_ASSUME_NONNULL_BEGIN
+@interface CustomConsentInterceptor : NSObject<RSConsentInterceptor>
+@end
+NS_ASSUME_NONNULL_END
+```
+</span>
+<li>Create a <code class="inline-code">CustomConsentInterceptor.m</code> file, as shown:</li>
+<br />
+
+<span>
+
+```objectivec
+#import "CustomConsentInterceptor.h"
+
+@implementation CustomConsentInterceptor
+
+- (nonnull RSMessage *)interceptWithServerConfig:(nonnull RSServerConfigSource *)serverConfig andMessage:(nonnull RSMessage *)message {
+    RSMessage *updatedMessage = message;
+    // Your code
+    return updatedMessage;
+}
+
+@end
+```
+</span>
+
+</ol>
+      </TabPanel>
+      <TabPanel>
+        <ol>
+            <li>Create a <code class="inline-code">CustomConsentInterceptor</code> file by extending <code class="inline-code">RSConsentInterceptor</code>, as shown:</li>
+            <br />
+
+<span>
+
+```swift
+@objc
+open class OneTrustInterceptor: NSObject, RSConsentInterceptor {
+    @objc
+    public override init() {
+        super.init()
+    }
+
+    public func intercept(
+        withServerConfig serverConfig: RSServerConfigSource, andMessage message: RSMessage
+    ) -> RSMessage {
+        let updatedMessage = message
+        // Your code
+        return updatedMessage
+    }
+}
+```
+</span>
+</ol>
+      </TabPanel>
+    </TabPanels>
+</Tabs>
+
+## Registering interceptor with iOS SDK
+
+You can register `CustomConsentInterceptor` with the iOS SDK during its initialization, as shown:
+
+<Tabs>
+  <TabList>
+    <Tab>Objective-C</Tab>
+    <Tab>Swift</Tab>
+  </TabList>
+    <TabPanels>
+      <TabPanel>
+        
+<span>
+
+```objectivec
+RSConfigBuilder *builder = [[RSConfigBuilder alloc] init];
+[builder withLoglevel:RSLogLevelDebug];
+[builder withDataPlaneUrl:DATA_PLANE_URL];
+[builder withConsentInterceptor:[[CustomConsentInterceptor alloc] init]];
+
+[RSClient getInstance:WRITE_KEY config:builder.build];
+```
+</span>
+      </TabPanel>
+      <TabPanel>
+
+<span>
+
+```swift
+let builder: RSConfigBuilder = RSConfigBuilder()
+    .withLoglevel(RSLogLevelDebug)
+    .withDataPlaneUrl(DATA_PLANE_URL)
+    .withConsentInterceptor(CustomConsentInterceptor())
+
+RSClient.getInstance(rudderConfig.WRITE_KEY, config: builder.build())
+```
+</span>
+      </TabPanel>
+    </TabPanels>
+</Tabs>
+
+## Installing OneTrust consent
+
+1. Install `RudderOneTrust` by adding the following line to your `Podfile`:
+
+```ruby
+pod 'RudderOneTrust', '~> 1.0.0'
+```
+
+2. Import the SDK, as shown:
+
+<Tabs>
+  <TabList>
+    <Tab>Objective-C</Tab>
+    <Tab>Swift</Tab>
+  </TabList>
+    <TabPanels>
+      <TabPanel>
+        
+<span>
+
+```objectivec
+@import RudderOneTrust;
+```
+</span>
+      </TabPanel>
+      <TabPanel>
+
+<span>
+
+```swift
+import RudderOneTrust
+```
+</span>
+      </TabPanel>
+    </TabPanels>
+</Tabs>
+
+3. Finally, add the imports to your `AppDelegate` file under the `didFinishLaunchingWithOptions` method, as shown:
+
+<Tabs>
+  <TabList>
+    <Tab>Objective-C</Tab>
+    <Tab>Swift</Tab>
+  </TabList>
+    <TabPanels>
+      <TabPanel>
+        
+<span>
+
+```objectivec
+[[OTPublishersHeadlessSDK shared] startSDKWithStorageLocation:STORAGE_LOCATION domainIdentifier:DOMAIN_IDENTIFIER languageCode:@"en" params:nil loadOffline:NO completionHandler:^(OTResponse *response) {
+    if (response.status) {
+        RSConfigBuilder *builder = [[RSConfigBuilder alloc] init];
+        [builder withLoglevel:RSLogLevelDebug];
+        [builder withDataPlaneUrl:DATA_PLANE_URL];
+        [builder withConsentInterceptor:[[OneTrustInterceptor alloc] init]];
+
+        [RSClient getInstance:rudderConfig.WRITE_KEY config:builder.build];
+    }
+}];
+```
+</span>
+      </TabPanel>
+      <TabPanel>
+
+<span>
+
+```swift
+OTPublishersHeadlessSDK.shared.startSDK(
+    storageLocation: STORAGE_LOCATION,
+    domainIdentifier: DOMAIN_IDENTIFIER,
+    languageCode: "en"
+) { response in
+    if response.status {
+        let builder: RSConfigBuilder = RSConfigBuilder()
+            .withLoglevel(RSLogLevelDebug)
+            .withDataPlaneUrl(DATA_PLANE_URL)
+            .withConsentInterceptor(OneTrustInterceptor())
+
+        RSClient.getInstance(rudderConfig.WRITE_KEY, config: builder.build())
+    }
+}
+```
+</span>
+      </TabPanel>
+    </TabPanels>
+</Tabs>
+
+<div class="warningBlock">
+Make sure you load the SDK only after initializing the OneTrust SDK successfully.
+</div>

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/ios.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/ios.mdx
@@ -1,0 +1,6 @@
+---
+title: "OneTrust-iOS SDK Integration"
+description: Integrate the RudderStack iOS SDK with OneTrust.
+aliases: ["OneTrust iOS SDK"]
+---
+

--- a/docs/sources/event-streams/sdks/consent-management/onetrust/web.mdx
+++ b/docs/sources/event-streams/sdks/consent-management/onetrust/web.mdx
@@ -1,0 +1,126 @@
+---
+title: "OneTrust-JavaScript SDK Integration"
+description: Integrate the RudderStack JavaScript SDK with the OneTrust SDK.
+aliases: ["OneTrust JavaScript SDK integration", "user session"]
+---
+
+<div class="warningBlock">
+The OneTrust integration with the JavaScript SDK is applicable only for the <Link to="/destinations/rudderstack-connection-modes/#device-mode">device mode</Link> connections. For the <Link to="/destinations/rudderstack-connection-modes/#cloud-mode">cloud mode</Link> connections, you can write a <Link to="/features/transformations/#adding-a-transformation">transformation</Link> to implement your desired use case.
+</div>
+
+The JavaScript SDK seamlessly integrates with the OneTrust SDK. It lets you map the OneTrust cookie/consent groups to RudderStack's consent purposes. RudderStack, in turn, uses this consent information to enable/disable tracking and sending the data.
+
+## How the OneTrust-JavaScript SDK integration works
+
+Whenever a user starts browsing a website, OneTrust pops up a modal to take consent from the user. This modal contains a list of cookie groups representing the GDPR consent purposes that the user needs to decline or accept.
+
+The JavaScript SDK fetches these consented groups and the destination (OneTrust category) mappings specified in the RudderStack dashboard. Depending on these settings, the SDK filters the destinations.
+
+## Setting up the integration
+
+The following sections highlight the steps to set up the JavaScript SDK integration with OneTrust.
+
+### Step 1: Configuring OneTrust
+
+Follow these steps to configure OneTrust for your web app:
+
+1. Create a [OneTrust account](https://my.onetrust.com/s/login/SelfRegister?language=en_US&startURL=%2Fs%2F%3Ft%3D1587743884774) and get subscription to their <Link to="https://www.onetrust.com/products/cookie-consent/">Cookie Consent</Link> product.
+2. Navigate to **Websites** > **Add Websites**. 
+3. Enter your top-level website URL to scan and click **Start Scan**.
+4. Go to the **Categorizations** tab and define the new categories or modify the existing ones, as required.
+
+<div class="infoBlock">
+The categories should be associated with/attached to at least one cookie to be displayed in your RudderStack dashboard's OneTrust modal.
+</div>
+
+5. Go to the **Scripts** tab, select the domain to be published and click **Publish** to publish the script.
+
+### Step 2: Specifying the OneTrust Cookie Categories
+
+You need to enable OneTrust for a given JavaScript source. To do so, specify the consent category names defined in OneTrust (**Step 1**) for each destination connected to that JavaScript source.
+
+<img src="../../../../../assets/event-stream-sources/onetrust-1.png" alt="OneTrust category names" />
+
+### Step 3: Setting up your website
+
+1. Load the OneTrust script that you published in your web app in <Link to="#step-1-configuring-onetrust">Step 1</Link>, as shown below:
+
+```javascript
+
+<!-- OneTrust Cookies Consent Notice start for samplewebsite.com -->
+<script
+        src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+        type="text/javascript"
+        charset="UTF-8"
+        data-domain-script="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" >
+</script>
+<script type="text/javascript">
+        // Required OneTrust callback
+        function OptanonWrapper() { }
+</script>
+<!-- OneTrust Cookies Consent Notice end for samplewebsite.com -->
+```
+
+<div class="warningBlock">
+As seen in the above snippet, you <strong>must</strong> first load the OneTrust script and then load the JavaScript SDK <strong>only if</strong> the user provides their consent. This is because the SDK determines whether to send events to a destination based on the user's consent. If a user denies consent in OneTrust, then Rudderstack does not load the destination SDKs or send any events to them.
+</div>
+
+2. One way to load the JavaScript SDK after the user provides the consent is to modify the `OptanonWrapper()` callback function provided by OneTrust. You also need to add the `cookieConsentManager` option in the `load()` call as shown:
+
+```javascript
+function OptanonWrapper() {
+  if (window.OneTrust.IsAlertBoxClosed()) {
+    // Load the SDK
+    rudderanalytics.load(WRITE_KEY, DATA_PLANE_URL, {
+      cookieConsentManager: {
+        oneTrust: {
+          enabled: true
+        }
+      },
+      //other options
+    });
+  }
+}
+```
+
+<div class="infoBlock">
+If a user updates the consent settings, the web page must be refreshed for the changes to take effect in the SDK.
+</div>
+
+Once completed, RudderStack reads the consented categories and filters the destinations accordingly.
+
+<div class="infoBlock">
+Replace <Link to="/resources/glossary/#write-key"><code class="inline-code">WRITE_KEY</code></Link> and <Link to="/dashboard-guides/overview/#data-plane-url"><code class="inline-code">DATA_PLANE_URL</code></Link> in the above snippet with the actual values.
+</div>
+
+## FAQ
+
+### What happens if the JavaScript SDK is loaded before the OneTrust modal is closed?
+
+In this case, the JavaScript SDK will not be able to capture the user consent. Hence, it will load all the connected destinations and all the events will flow through to them.
+
+### Can I integrate the RudderStack JavaScript SDK with any consent manager?
+
+If you are using a consent manager other than OneTrust, you can configure the cookie categories to show on your website whenever a user visits.
+
+Next, you need to create an internal mapping between these cookie categories and the destinations configured in RudderStack. For example:
+
+- Analytical cookie: Amplitude, Google Analytics
+- Targeting cookie: Bing Ads, Google Ads
+- Marketing cookie: Braze, Mailchimp, Customer.io
+
+When the user provides consent, you should fetch the consent (via the API or SDK provided by your consent manager) and filter the destinations depending on the consent. Once you have the list of destinations for which the user has provided consent, you can load the JavaScript SDK only for those destinations.
+
+For example, if a user has provided consent for an analytical cookie, then you can load the JavaScript SDK as shown:
+
+```javascript
+rudderanalytics.load(WRITE_KEY,DATA_PLANE_URL,{
+   integrations: {
+       All: false,
+       "Amplitude": true,
+       "Google Analytics": true
+       // only provide the destinations the user has provide consent for
+   }
+   // pass other initialization options
+});
+```

--- a/docs/sources/event-streams/sdks/rudderstack-android-sdk/index.mdx
+++ b/docs/sources/event-streams/sdks/rudderstack-android-sdk/index.mdx
@@ -874,6 +874,10 @@ rudderClient.identify(
 )
 ```
 
+## OneTrust consent management
+
+The Android SDK lets you specify the user's consent during initialization. For more information, refer to the <Link to="/sources/event-streams/sdks/consent-management/onetrust/android/">OneTrust Consent Management for Android SDK</Link> guide.
+
 ## Tracking user sessions
 
 By default, the Android SDK automatically tracks the user sessions. This means that RudderStack automatically determines the start and end of a user session depending on the inactivity time configured in the SDK (default time is 5 minutes).

--- a/docs/sources/event-streams/sdks/rudderstack-ios-sdk/index.mdx
+++ b/docs/sources/event-streams/sdks/rudderstack-ios-sdk/index.mdx
@@ -249,6 +249,10 @@ You can disable these events using the <code class="inline-code">withTrackLifecy
 
 RudderStack supports all the major API calls across all iOS devices via the SDK. These include the `track`, `identify`, and `screen` calls.
 
+## OneTrust consent management
+
+The iOS SDK lets you specify the user's consent during initialization. For more information, refer to the <Link to="/sources/event-streams/sdks/consent-management/onetrust/ios/">OneTrust Consent Management for iOS SDK</Link> guide.
+
 ## Enabling/disabling user tracking via the optOut API \(GDPR support\)
 
 RudderStack gives the users \(e.g., an EU user\) the ability to opt out of tracking any user activity until the user gives their consent. You can do this by leveraging RudderStack's `optOut` API.

--- a/docs/sources/event-streams/sdks/rudderstack-ios-sdk/ios-v2.mdx
+++ b/docs/sources/event-streams/sdks/rudderstack-ios-sdk/ios-v2.mdx
@@ -574,6 +574,10 @@ Alternatively, you can use the following method signature:
 RudderStack replaces the old <code class="inline-code">userId</code> with the <code class="inline-code">newUserId</code> and persists that identification across the sessions.
 </div>
 
+## OneTrust consent management
+
+The iOS SDK lets you specify the user's consent during initialization. For more information, refer to the <Link to="/sources/event-streams/sdks/consent-management/onetrust/ios/">OneTrust Consent Management for iOS SDK</Link> guide.
+
 ## Reset
 
 You can use the `reset` method to clear the persisted user traits from the `identify` call. This is required for the user logout operation.

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -167,7 +167,7 @@ export const jsonData = [
                             },
                             {
                                 title: "OneTrust Consent Manager",
-                                link: "/sources/event-streams/sdks/rudderstack-javascript-sdk/onetrust-consent-manager/",
+                                link: "/sources/event-streams/sdks/consent-management/onetrust/web/",
                                 content: [],
                             },
                             {
@@ -292,8 +292,35 @@ export const jsonData = [
                         content: []
                     },
                     {
-                        title: "Client-side Event Filtering",
+                        title: "Consent Management",
                         sectionTitle: "Features",
+                        link: "/sources/event-streams/sdks/consent-management/",
+                        content: [
+                            {
+                                title: "OneTrust",
+                                link: "/sources/event-streams/sdks/consent-management/onetrust/",
+                                content: [
+                                    {
+                                        title: "Web",
+                                        link: "/sources/event-streams/sdks/consent-management/onetrust/web/",
+                                        content: []
+                                    },
+                                    {
+                                        title: "Android",
+                                        link: "/sources/event-streams/sdks/consent-management/onetrust/android/",
+                                        content: []
+                                    },
+                                    {
+                                        title: "iOS",
+                                        link: "/sources/event-streams/sdks/consent-management/onetrust/ios/",
+                                        content: []
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        title: "Client-side Event Filtering",
                         link: "/sources/event-streams/sdks/event-filtering/",
                         content: []
                     },

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -167,7 +167,7 @@ export const jsonData = [
                             },
                             {
                                 title: "OneTrust Consent Manager",
-                                link: "/sources/event-streams/sdks/consent-management/onetrust/web/",
+                                link: "/sources/event-streams/sdks/rudderstack-javascript-sdk/onetrust-consent-manager/",
                                 content: [],
                             },
                             {
@@ -301,7 +301,7 @@ export const jsonData = [
                                 link: "/sources/event-streams/sdks/consent-management/onetrust/",
                                 content: [
                                     {
-                                        title: "Web",
+                                        title: "JavaScript",
                                         link: "/sources/event-streams/sdks/consent-management/onetrust/web/",
                                         content: []
                                     },


### PR DESCRIPTION
## What do these changes do?

> **Restructuring**: Added consent management as a separate section under **SDK** > **Features**.
> **New Docs**: Added new docs for OneTrust consent management for JS, Android and iOS SDK.

## Type of documentation

- [x] New documentation
- [x] Documentation update
- [ ] Hotfix
