### PR TITLE
chore: fix regulation API doc for destinationIds

### DIFF
--- a/docs/api/data-regulation-api.mdx
+++ b/docs/api/data-regulation-api.mdx
@@ -126,7 +126,7 @@ You can set these **optional** fields to specify the sources or destinations fro
 
 - Specify **only `sourceIds`** when setting the `regulationType` to `suppress`. If no `sourceIds` are specified, RudderStack will suppress data from all the sources present in the workspace associated with the access token.
 
-- Specify **only `destinationIds`** when setting the `regulationType` to `suppress_with_delete`. 
+- You must specify the **`destinationIds`** when the `regulationType` is set to `suppress_with_delete`. Otherwise, RudderStack throws an error.
 
 <div class="infoBlock">
 <ul>

--- a/docs/api/data-regulation-api.mdx
+++ b/docs/api/data-regulation-api.mdx
@@ -126,7 +126,7 @@ You can set these **optional** fields to specify the sources or destinations fro
 
 - Specify **only `sourceIds`** when setting the `regulationType` to `suppress`. If no `sourceIds` are specified, RudderStack will suppress data from all the sources present in the workspace associated with the access token.
 
-- Specify **only `destinationIds`** when setting the `regulationType` to `suppress_with_delete`. If no `destinationIds` are specified, RudderStack will delete the data for all the destinations present in the workspace.
+- Specify **only `destinationIds`** when setting the `regulationType` to `suppress_with_delete`. 
 
 <div class="infoBlock">
 <ul>


### PR DESCRIPTION
## What do these changes do?

> We no longer deletion from all the destinations, if no `destinationId` is specified. It is a must have field when regulation type is `suppress_with_delete` & we throw error, if it is not present.

## Type of documentation

- [ ] New documentation
- [x ] Documentation update
- [ ] Hotfix
