### PR TITLE
fix: list integration sdks url

### DIFF
--- a/docs/user-guides/how-to-guides/self-hosting-js-sdk.mdx
+++ b/docs/user-guides/how-to-guides/self-hosting-js-sdk.mdx
@@ -6,7 +6,7 @@ description: Host the RudderStack JavaScript SDK on your own CDN or storage loca
 This guide walks you through the steps to self-host the RudderStack JavaScript SDK and also covers different scenarios based on your directory structure.
 
 1. Download the [JavaScript SDK](https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js) and save it as `rudder-analytics.min.js`. Also, download the [corresponding source map file](https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js.map), and save it as `rudder-analytics.min.js.map`.
-2. Download the required device mode destination SDK file (`<dest_name>.min.js`) and its corresponding source map file (`<dest_name>.min.js.map`) from [RudderStack CDN](https://cdn.rudderlabs.com/v1.1/list_integration_sdks.html).
+2. Download the required device mode destination SDK file (`<dest_name>.min.js`) and its corresponding source map file (`<dest_name>.min.js.map`) from [RudderStack CDN](https://cdn.rudderlabs.com/v1.1/list_integration_sdks_static.html).
 
 <div class="infoBlock">
 Downloading and hosting the source map files (<code class="inline-code">rudder-analytics.min.js.map</code> or <code class="inline-code">&lt;dest_name&gt;.min.js.map</code>) is optional but recommended to help in troubleshooting.


### PR DESCRIPTION
## What do these changes do?

As this link, https://cdn.rudderlabs.com/v1.1/list_integration_sdks.html is not working (temporarily), I've replaced it with, https://cdn.rudderlabs.com/v1.1/list_integration_sdks_static.html

## Type of documentation

- [ ] New documentation
- [ ] Documentation update
- [x] Hotfix
