### PR TITLE
docs: fix appsflyerExternalId in appsflyer streaming destination docs

### DIFF
--- a/docs/destinations/streaming-destinations/appsflyer.mdx
+++ b/docs/destinations/streaming-destinations/appsflyer.mdx
@@ -613,7 +613,7 @@ The following table lists the `externalId` fields:
 | Field | Description|
 | :----| :------------|
 | `id` | Your AppsFlyer ID. |
-| `type`| The type of `externalId`. This must always be set to `appsFlyerExternalId`. |
+| `type`| The type of `externalId`. This must always be set to `appsflyerExternalId`. |
 
 ### Obtaining the AppsFlyer ID
 


### PR DESCRIPTION
## What do these changes do?

This PR fixes misspell in `appsFlyerExternalId` to `appsflyerExternalId` in the Appsflyer streaming destination docs.

See https://github.com/rudderlabs/rudder-sdk-react-native/issues/381#issuecomment-2399431279 for confirmation that `appsflyerExternalId` is the correct format.

## Type of documentation

- [ ] New documentation
- [x] Documentation update
- [ ] Hotfix
